### PR TITLE
Drop python3 compatibility code

### DIFF
--- a/pointless_ext.c
+++ b/pointless_ext.c
@@ -7,12 +7,7 @@ struct pointless_module_state {
 //	PyObject *error;
 };
 
-#if PY_MAJOR_VERSION >= 3
 #define GETSTATE(m) ((struct pointless_module_state*)PyModule_GetState(m))
-#else
-#define GETSTATE(m) (&_state)
-static struct pointless_module_state _state;
-#endif
 
 static struct PyPointless_CAPI CAPI = {
 	POINTLESS_API_MAGIC,
@@ -72,8 +67,6 @@ static PyMethodDef pointless_module_methods[] =
 	{NULL, NULL},
 };
 
-#if PY_MAJOR_VERSION >= 3
-
 static int pointless_module_traverse(PyObject* m, visitproc visit, void* arg) {
 //	Py_VISIT(GETSTATE(m)->error);
 	return 0;
@@ -95,21 +88,11 @@ static struct PyModuleDef moduledef = {
 	pointless_module_clear,
 	NULL
 };
-#endif
 
-#if PY_MAJOR_VERSION >= 3
 #define MODULEINITERROR return NULL
 PyMODINIT_FUNC
-#else
-#define MODULEINITERROR return
-void
-#endif
 
-#if PY_MAJOR_VERSION >= 3
 PyInit_pointless(void)
-#else
-initpointless(void)
-#endif
 {
 	if (sizeof(Word_t) != sizeof(void*)) {
 		PyErr_SetString(PyExc_ValueError, "word size mismatch");
@@ -118,11 +101,7 @@ initpointless(void)
 
 	PyObject* module_pointless = 0;
 
-#if PY_MAJOR_VERSION >= 3
 	module_pointless = PyModule_Create(&moduledef);
-#else
-	module_pointless = Py_InitModule4("pointless", pointless_module_methods, "Pointless Python API", 0, PYTHON_API_VERSION);
-#endif
 
 	if (module_pointless == 0) {
 		MODULEINITERROR;
@@ -180,9 +159,7 @@ initpointless(void)
 		MODULEINITERROR;
 	}
 
-#if PY_MAJOR_VERSION >= 3
     return module_pointless;
-#endif
 }
 
 #undef MODULEINITERROR

--- a/python/pointless_bitvector.c
+++ b/python/pointless_bitvector.c
@@ -108,10 +108,6 @@ static int PyPointlessBitvector_init(PyPointlessBitvector* self, PyObject* args,
 
 			if (PyErr_Occurred())
 				return -1;
-#if PY_MAJOR_VERSION < 3
-		} else if (PyInt_Check(size) || PyInt_CheckExact(size)) {
-			n_items = (Py_ssize_t)PyInt_AS_LONG(size);
-#endif
 		} else {
 			is_error = 1;
 		}
@@ -166,14 +162,6 @@ static int PyPointlessBitvector_init(PyPointlessBitvector* self, PyObject* args,
 					bm_set_(self->primitive_bits, i);
 					self->primitive_n_one += 1;
 				}
-			// 2) integer (must be 0 or 1)
-#if PY_MAJOR_VERSION < 3
-			} else if ((PyInt_Check(obj) || PyInt_CheckExact(obj)) && (PyInt_AS_LONG(obj) == 0 || PyInt_AS_LONG(obj) == 1)) {
-				if (PyInt_AS_LONG(obj) == 1) {
-					bm_set_(self->primitive_bits, i);
-					self->primitive_n_one += 1;
-				}
-#endif
 			// 3) long (must be 0 or 1)
 			} else if (PyLong_Check(obj) || PyLong_CheckExact(obj)) {
 				PY_LONG_LONG v = PyLong_AsLongLong(obj);
@@ -302,17 +290,6 @@ static int PyPointlessBitvector_ass_subscript(PyPointlessBitvector* self, PyObje
 		else if (v == 1)
 			i_value = 1;
 	}
-
-#if PY_MAJOR_VERSION < 3
-	if (PyInt_Check(value)) {
-		long v = PyInt_AS_LONG(value);
-
-		if (v == 0)
-			i_value = 0;
-		else if (v == 1)
-			i_value = 1;
-	}
-#endif
 
 	if (i_value == 0) {
 		bm_reset_(self->primitive_bits, i);
@@ -808,11 +785,7 @@ static long PyPointlessBitVector_hash(PyPointlessBitvector* self)
 PyObject* PyBitvector_repr(PyPointlessBitvector* self)
 {
 	if (!self->is_pointless && !self->allow_print) {
-#if PY_MAJOR_VERSION < 3
-		return PyString_FromFormat("<%s object at %p>", Py_TYPE(self)->tp_name, (void*)self);
-#else
 		return PyUnicode_FromFormat("<%s object at %p>", Py_TYPE(self)->tp_name, (void*)self);
-#endif
 	}
 
 	return PyPointless_repr((PyObject*)self);
@@ -821,11 +794,7 @@ PyObject* PyBitvector_repr(PyPointlessBitvector* self)
 PyObject* PyBitvector_str(PyPointlessBitvector* self)
 {
 	if (!self->is_pointless && !self->allow_print) {
-#if PY_MAJOR_VERSION < 3
-		return PyString_FromFormat("<%s object at %p>", Py_TYPE(self)->tp_name, (void*)self);
-#else
 		return PyUnicode_FromFormat("<%s object at %p>", Py_TYPE(self)->tp_name, (void*)self);
-#endif
 	}
 
 	return PyPointless_str((PyObject*)self);

--- a/python/pointless_instance_dispatch.c
+++ b/python/pointless_instance_dispatch.c
@@ -3,11 +3,7 @@
 static PyObject* pointless_int_to_python(int64_t v)
 {
 	if (LONG_MIN <= v && v <= LONG_MAX) {
-		#if PY_MAJOR_VERSION >= 3
 		return PyLong_FromLong((long)v);
-		#else
-		return PyInt_FromLong((long)v);
-		#endif
 	} else if (LLONG_MIN <= v && v <= LLONG_MAX)
 		return PyLong_FromLongLong((PY_LONG_LONG)v);
 	else
@@ -17,11 +13,7 @@ static PyObject* pointless_int_to_python(int64_t v)
 static PyObject* pointless_uint_to_python(uint64_t v)
 {
 	if (v <= LONG_MAX) {
-		#if PY_MAJOR_VERSION >= 3
 		return PyLong_FromLong((long)v);
-		#else
-		return PyInt_FromLong((long)v);
-		#endif
 	} else if (v <= LLONG_MAX)
 		return PyLong_FromLongLong((PY_LONG_LONG)v);
 	else if (v <= ULLONG_MAX)
@@ -87,45 +79,10 @@ PyObject* pypointless_value_unicode(pointless_t* p, pointless_value_t* v)
 #endif
 }
 
-#if PY_MAJOR_VERSION < 3
-static int pointless_value_string_is_7bit(uint8_t* s)
-{
-	while (*s) {
-		if (*s >= 128)
-			return 0;
-
-		s++;
-	}
-
-	return 1;
-}
-#endif
-
 PyObject* pypointless_value_string(pointless_t* p, pointless_value_t* v)
 {
 	uint8_t* string_ascii = pointless_reader_string_value_ascii(p, v);
-
-	// if 7-bit, string, otherwise unicode
-
-	#if PY_MAJOR_VERSION < 3
-
-	if (pointless_value_string_is_7bit(string_ascii)) {
-		return PyString_FromString((const char*)string_ascii);
-	}
-
-	#endif
-
 	return PyUnicode_DecodeLatin1((const char*)string_ascii, strlen((const char*)string_ascii), 0);
-
-	// we do this for a reason, this, in Python 2.7 fails:
-	//
-	// u'\x80'.startswith('\x80')
-	//
-	// but
-	//
-	// u'\x80'.startswith('\x80'.decode('latin1')) 
-	//
-	// does not
 }
 
 PyObject* pypointless_value(PyPointless* p, pointless_value_t* v)

--- a/python/pointless_map.c
+++ b/python/pointless_map.c
@@ -234,7 +234,7 @@ static PyObject* PyPointlessMap_contains(PyPointlessMap* m, PyObject* k)
 	return PyBool_FromLong(i);
 }
 
-static PyObject* PyPointlessMap_iterkeys(PyPointlessMap* m)
+static PyObject* PyPointlessMap_keys(PyPointlessMap* m)
 {
 	PyPointlessMapKeyIter* iter = (PyPointlessMapKeyIter*)PyObject_New(PyPointlessMapKeyIter, &PyPointlessMapKeyIterType);
 
@@ -248,7 +248,7 @@ static PyObject* PyPointlessMap_iterkeys(PyPointlessMap* m)
 	return (PyObject*)iter;
 }
 
-static PyObject* PyPointlessMap_itervalues(PyPointlessMap* m)
+static PyObject* PyPointlessMap_values(PyPointlessMap* m)
 {
 	PyPointlessMapValueIter* iter = (PyPointlessMapValueIter*)PyObject_New(PyPointlessMapValueIter, &PyPointlessMapValueIterType);
 
@@ -262,7 +262,7 @@ static PyObject* PyPointlessMap_itervalues(PyPointlessMap* m)
 	return (PyObject*)iter;
 }
 
-static PyObject* PyPointlessMap_iteritems(PyPointlessMap* m)
+static PyObject* PyPointlessMap_items(PyPointlessMap* m)
 {
 	PyPointlessMapItemIter* iter = (PyPointlessMapItemIter*)PyObject_New(PyPointlessMapItemIter, &PyPointlessMapItemIterType);
 
@@ -349,82 +349,14 @@ static PyObject* PyPointlessMap_get(PyPointlessMap* m, PyObject* args)
 	return pypointless_value(m->pp, v);
 }
 
-#define PyPointlessMap_LIST_TYPE_KEYS 0
-#define PyPointlessMap_LIST_TYPE_VALUES 1
-#define PyPointlessMap_LIST_TYPE_ITEMS 2
-
-static PyObject* PyPointlessMap_to_list(PyPointlessMap* m, int list_type)
-{
-	uint32_t n_items = pointless_reader_map_n_items(&m->pp->p, m->v);
-	PyObject* retval = PyList_New(n_items);
-	Py_ssize_t i = 0;
-
-	if (retval == 0)
-		goto error;
-
-	uint32_t iter_state = 0;
-
-	pointless_value_t* k = 0;
-	pointless_value_t* v = 0;
-
-	while (pointless_reader_map_iter(&m->pp->p, m->v, &k, &v, &iter_state)) {
-		PyObject* item = 0;
-
-		switch (list_type) {
-			case PyPointlessMap_LIST_TYPE_KEYS:
-				item = pypointless_value(m->pp, k);
-				break;
-			case PyPointlessMap_LIST_TYPE_VALUES:
-				item = pypointless_value(m->pp, v);
-				break;
-			case PyPointlessMap_LIST_TYPE_ITEMS:
-				item = Py_BuildValue("(NN)", pypointless_value(m->pp, k), pypointless_value(m->pp, v));
-				break;
-			default:
-				PyErr_SetString(PyExc_ValueError, "PyPointlessMap_to_list(): internal error");
-				goto error;
-		}
-
-		if (item == 0)
-			goto error;
-
-		PyList_SET_ITEM(retval, i, item);
-		i += 1;
-	}
-
-	return retval;
-
-error:
-	Py_XDECREF(retval);
-
-	return 0;
-}
-
-static PyObject* PyPointlessMap_keys(PyPointlessMap* m)
-{
-	return PyPointlessMap_to_list(m, PyPointlessMap_LIST_TYPE_KEYS);
-}
-
-static PyObject* PyPointlessMap_values(PyPointlessMap* m)
-{
-	return PyPointlessMap_to_list(m, PyPointlessMap_LIST_TYPE_VALUES);
-}
-
-static PyObject* PyPointlessMap_items(PyPointlessMap* m)
-{
-	return PyPointlessMap_to_list(m, PyPointlessMap_LIST_TYPE_ITEMS);
-}
 
 static PyMethodDef PyPointlessMap_methods[] = {
 	{"__contains__", (PyCFunction)PyPointlessMap_contains,    METH_O | METH_COEXIST, ""},
 	{"__getitem__",  (PyCFunction)PyPointlessMap_subscript,   METH_O | METH_COEXIST, ""},
 	{"get",          (PyCFunction)PyPointlessMap_get,         METH_VARARGS, ""},
 	{"keys",         (PyCFunction)PyPointlessMap_keys,        METH_NOARGS, ""},
-	{"items",        (PyCFunction)PyPointlessMap_items,       METH_NOARGS, ""},
 	{"values",       (PyCFunction)PyPointlessMap_values,      METH_NOARGS, ""},
-	{"iterkeys",     (PyCFunction)PyPointlessMap_iterkeys,    METH_NOARGS, ""},
-	{"itervalues",   (PyCFunction)PyPointlessMap_itervalues,  METH_NOARGS, ""},
-	{"iteritems",    (PyCFunction)PyPointlessMap_iteritems,   METH_NOARGS, ""},
+	{"items",        (PyCFunction)PyPointlessMap_items,       METH_NOARGS, ""},
 	{NULL, NULL}
 };
 

--- a/python/pointless_object.c
+++ b/python/pointless_object.c
@@ -184,16 +184,8 @@ static int PyPointless_init(PyPointless* self, PyObject* args, PyObject* kwds)
 		if (string_of_unicode == 0)
 			return -1;
 
-#if PY_MAJOR_VERSION < 3
-		fname_ = PyString_AS_STRING(string_of_unicode);
-#else
 		fname_ = PyBytes_AS_STRING(string_of_unicode);
-#endif
 
-#if PY_MAJOR_VERSION < 3
-	} else if (PyString_Check(fname_or_buffer)) {
-		fname_ = PyString_AS_STRING(fname_or_buffer);
-#endif
 	} else if (PyPointlessPrimVector_Check(fname_or_buffer)) {
 		vector = (PyPointlessPrimVector*)fname_or_buffer;
 

--- a/python/pointless_prim_vector.c
+++ b/python/pointless_prim_vector.c
@@ -558,7 +558,7 @@ static PyObject* PyPointlessPrimVector_subscript(PyPointlessPrimVector* self, Py
 	if (PySlice_Check(item)) {
 		Py_ssize_t start, stop, step, slicelength;
 
-		if (PySlice_GetIndicesEx((PySliceObject*)item, (Py_ssize_t)pointless_dynarray_n_items(&self->array), &start, &stop, &step, &slicelength) == -1)
+		if (PySlice_GetIndicesEx(item, (Py_ssize_t)pointless_dynarray_n_items(&self->array), &start, &stop, &step, &slicelength) == -1)
 			return 0;
 
 		if (step != 1) {

--- a/python/pointless_prim_vector.c
+++ b/python/pointless_prim_vector.c
@@ -17,21 +17,6 @@ typedef union {
 
 static int parse_pyobject_number(PyObject* v, int* is_signed, int64_t* i, uint64_t* u)
 {
-#if PY_MAJOR_VERSION < 3
-	// simple case
-	if (PyInt_Check(v)) {
-		long _v = PyInt_AS_LONG(v);
-		if (_v < 0) {
-			*is_signed = 1;
-			*i = (int64_t)_v;
-		} else {
-			*is_signed = 0;
-			*u = (uint64_t)_v;
-		}
-
-		return 1;
-	}
-#endif
 	// complicated case
 	if (!PyLong_Check(v)) {
 		PyErr_SetString(PyExc_TypeError, "expected an integer");
@@ -200,11 +185,7 @@ static int PyPointlessPrimVectorIter_traverse(PyPointlessPrimVectorIter* self, v
 PyObject* PyPointlessPrimVector_str(PyPointlessPrimVector* self)
 {
 	if (!self->allow_print) {
-#if PY_MAJOR_VERSION < 3
-		return PyString_FromFormat("<%s object at %p>", Py_TYPE(self)->tp_name, (void*)self);
-#else
 		return PyUnicode_FromFormat("<%s object at %p>", Py_TYPE(self)->tp_name, (void*)self);
-#endif
 	}
 
 	pointless_dynarray_t string;
@@ -285,11 +266,7 @@ PyObject* PyPointlessPrimVector_str(PyPointlessPrimVector* self)
 		goto error;
 	}
 
-#if PY_MAJOR_VERSION < 3
-	PyObject* v_s = PyString_FromString(pointless_dynarray_buffer(&string));
-#else
 	PyObject* v_s = PyUnicode_FromString(pointless_dynarray_buffer(&string));
-#endif
 
 	pointless_dynarray_destroy(&string);
 
@@ -547,36 +524,16 @@ static PyObject* PyPointlessPrimVector_subscript_priv(PyPointlessPrimVector* sel
 
 	switch (self->type) {
 		case POINTLESS_PRIM_VECTOR_TYPE_I8:
-#if PY_MAJOR_VERSION < 3
-			return PyInt_FromLong((long)(*((int8_t*)base_value)));
-#else
 			return PyLong_FromLong((long)(*((int8_t*)base_value)));
-#endif
 		case POINTLESS_PRIM_VECTOR_TYPE_U8:
-#if PY_MAJOR_VERSION < 3
-			return PyInt_FromLong((long)(*((uint8_t*)base_value)));
-#else
 			return PyLong_FromLong((long)(*((uint8_t*)base_value)));
-#endif
 		case POINTLESS_PRIM_VECTOR_TYPE_I16:
-#if PY_MAJOR_VERSION < 3
-			return PyInt_FromLong((long)(*((int16_t*)base_value)));
-#else
 			return PyLong_FromLong((long)(*((int16_t*)base_value)));
-#endif
 		case POINTLESS_PRIM_VECTOR_TYPE_U16:
-#if PY_MAJOR_VERSION < 3
-			return PyInt_FromLong((long)(*((uint16_t*)base_value)));
-#else
 			return PyLong_FromLong((long)(*((uint16_t*)base_value)));
-#endif
 
 		case POINTLESS_PRIM_VECTOR_TYPE_I32:
-#if PY_MAJOR_VERSION < 3
-			return PyInt_FromLong((long)(*((int32_t*)base_value)));
-#else
 			return PyLong_FromLong((long)(*((int32_t*)base_value)));
-#endif
 		case POINTLESS_PRIM_VECTOR_TYPE_U32:
 			return PyLong_FromUnsignedLong((unsigned long)(*((uint32_t*)base_value)));
 		case POINTLESS_PRIM_VECTOR_TYPE_I64:
@@ -1034,11 +991,7 @@ static PyObject* PyPointlessPrimVector_index(PyPointlessPrimVector* self, PyObje
 	if (i == (SIZE_MAX-1))
 		return 0;
 
-#if PY_MAJOR_VERSION < 3
-	return PyInt_FromSize_t(i);
-#else
 	return PyLong_FromSize_t(i);
-#endif
 }
 
 static PyObject* PyPointlessPrimVector_remove(PyPointlessPrimVector* self, PyObject* args)
@@ -1153,49 +1106,6 @@ static PyObject* PyPointlessPrimVector_clear(PyPointlessPrimVector* self)
 }
 
 
-#if PY_MAJOR_VERSION < 3
-static Py_ssize_t PointlessPrimVector_buffer_getreadbuf(PyPointlessPrimVector* self, Py_ssize_t index, const void** ptr)
-{
-	if (index != 0 ) {
-		PyErr_SetString(PyExc_SystemError, "accessing non-existent bytes segment");
-		return -1;
-	}
-
-	*ptr = (void*)pointless_dynarray_buffer(&self->array);
-	return (Py_ssize_t)PyPointlessPrimVector_n_bytes(self);
-}
-
-static Py_ssize_t PointlessPrimVector_buffer_getwritebuf(PyPointlessPrimVector* self, Py_ssize_t index, const void** ptr)
-{
-	if (index != 0) {
-		PyErr_SetString(PyExc_SystemError, "accessing non-existent bytes segment");
-		return -1;
-	}
-
-	*ptr = (void*)pointless_dynarray_buffer(&self->array);
-	return (Py_ssize_t)PyPointlessPrimVector_n_bytes(self);
-}
-
-static Py_ssize_t PointlessPrimVector_buffer_getsegcount(PyPointlessPrimVector* self, Py_ssize_t* lenp)
-{
-	if (lenp)
-		*lenp = (Py_ssize_t)PyPointlessPrimVector_n_bytes(self);
-
-	return 1;
-}
-
-static Py_ssize_t PointlessPrimVector_buffer_getcharbuf(PyPointlessPrimVector* self, Py_ssize_t index, const char** ptr)
-{
-	if (index != 0) {
-		PyErr_SetString(PyExc_SystemError, "accessing non-existent bytes segment");
-		return -1;
-	}
-
-	*ptr = (void*)pointless_dynarray_buffer(&self->array);
-	return (Py_ssize_t)PyPointlessPrimVector_n_bytes(self);
-}
-#endif
-
 static int PointlessPrimVector_getbuffer(PyPointlessPrimVector* obj, Py_buffer* view, int flags)
 {
 	int ret;
@@ -1221,12 +1131,6 @@ static void PointlessPrimVector_releasebuffer(PyPointlessPrimVector* obj, Py_buf
 }
 
 static PyBufferProcs PointlessPrimVector_as_buffer = {
-#if PY_MAJOR_VERSION < 3
-	(readbufferproc)PointlessPrimVector_buffer_getreadbuf,
-	(writebufferproc)PointlessPrimVector_buffer_getwritebuf,
-	(segcountproc)PointlessPrimVector_buffer_getsegcount,
-	(charbufferproc)PointlessPrimVector_buffer_getcharbuf,
-#endif
 	(getbufferproc)PointlessPrimVector_getbuffer,
 	(releasebufferproc)PointlessPrimVector_releasebuffer,
 };
@@ -2047,11 +1951,7 @@ PyTypeObject PyPointlessPrimVectorType = {
 	PyObject_GenericGetAttr,                                              /*tp_getattro*/
 	0,                                              /*tp_setattro*/
 	&PointlessPrimVector_as_buffer,                 /*tp_as_buffer*/
-#if PY_MAJOR_VERSION < 3
-	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_NEWBUFFER, /*tp_flags*/
-#else
 	Py_TPFLAGS_DEFAULT,                             /*tp_flags*/
-#endif
 	"PyPointlessPrimVector wrapper",                /*tp_doc */
 	0,                                              /*tp_traverse */
 	0,                                              /*tp_clear */

--- a/python/pointless_pyobject_hash.c
+++ b/python/pointless_pyobject_hash.c
@@ -109,41 +109,10 @@ static uint32_t pyobject_hash_unicode_32(PyObject* py_object, pyobject_hash_stat
 	return hash;
 }
 
-#if PY_MAJOR_VERSION < 3
-static uint32_t pyobject_hash_string_32(PyObject* py_object, pyobject_hash_state_t* state)
-{
-	char* s = PyString_AS_STRING(py_object);
-	return pointless_hash_string_v1_32((uint8_t*)s);
-}
-#endif
-
 static uint32_t pyobject_hash_pypointlessbitvector_32(PyObject* py_object, pyobject_hash_state_t* state)
 {
 	return pointless_pybitvector_hash_32((PyPointlessBitvector*)py_object);
 }
-
-#if PY_MAJOR_VERSION < 3
-static uint32_t pyobject_hash_int_32(PyObject* py_object, pyobject_hash_state_t* state)
-{
-	long i = PyInt_AS_LONG(py_object);
-
-	if (i < 0) {
-		if (!(INT32_MIN <= i && i <= INT32_MAX)) {
-			*state->error = "hashing of integers exceeding 32-bits not supported";
-			return 0;
-		}
-
-		return pointless_hash_i32_32((int32_t)i);
-	}
-
-	if (!(i <= UINT32_MAX)) {
-		*state->error = "hashing of integers exceeding 32-bits not supported";
-		return 0;
-	}
-
-	return pointless_hash_u32_32((uint32_t)i);
-}
-#endif
 
 static uint32_t pyobject_hash_long_32(PyObject* py_object, pyobject_hash_state_t* state)
 {
@@ -234,11 +203,6 @@ static uint32_t pyobject_hash_rec_32(PyObject* py_object, pyobject_hash_state_t*
 		return pyobject_hash_primvector_32((PyPointlessPrimVector*)py_object, state);
 
 	// early checks for more common types
-#if PY_MAJOR_VERSION < 3
-	if (PyInt_Check(py_object))
-		return pyobject_hash_int_32(py_object, state);
-#endif
-
 	if (PyLong_Check(py_object))
 		return pyobject_hash_long_32(py_object, state);
 
@@ -247,11 +211,6 @@ static uint32_t pyobject_hash_rec_32(PyObject* py_object, pyobject_hash_state_t*
 
 	if (PyUnicode_Check(py_object))
 		return pyobject_hash_unicode_32(py_object, state);
-
-#if PY_MAJOR_VERSION < 3
-	if (PyString_Check(py_object))
-		return pyobject_hash_string_32(py_object, state);
-#endif
 
 	if (PyPointlessBitvector_Check(py_object))
 		return pyobject_hash_pypointlessbitvector_32(py_object, state);
@@ -306,11 +265,6 @@ PyObject* pointless_pyobject_hash_32(PyObject* self, PyObject* args)
 		PyErr_Format(PyExc_ValueError, "PyObject hashing error: %s", error);
 		return 0;
 	}
-
-#if PY_MAJOR_VERSION < 3
-	if (hash < LONG_MAX)
-		return PyInt_FromLong((long)hash);
-#endif
 
 	return PyLong_FromUnsignedLongLong((unsigned PY_LONG_LONG)hash);
 }

--- a/python/pointless_vector.c
+++ b/python/pointless_vector.c
@@ -138,7 +138,7 @@ static PyObject* PyPointlessVector_subscript(PyPointlessVector* self, PyObject* 
 	if (PySlice_Check(item)) {
 		Py_ssize_t start, stop, step, slicelength;
 
-		if (PySlice_GetIndicesEx((PySliceObject*)item, (Py_ssize_t)self->slice_n, &start, &stop, &step, &slicelength) == -1)
+		if (PySlice_GetIndicesEx(item, (Py_ssize_t)self->slice_n, &start, &stop, &step, &slicelength) == -1)
 			return 0;
 
 		if (step != 1) {

--- a/python/pointless_vector.c
+++ b/python/pointless_vector.c
@@ -443,43 +443,6 @@ static void* pointless_prim_vector_base_ptr(PyPointlessVector* self)
 	return 0;
 }
 
-#if PY_MAJOR_VERSION < 3
-static Py_ssize_t PyPointlessVector_buffer_getreadbuf(PyPointlessVector* self, Py_ssize_t index, const void **ptr)
-{
-	if (index != 0) {
-		PyErr_SetString(PyExc_SystemError, "accessing non-existent bytes segment");
-		return -1;
-	}
-
-	if (!pointless_is_prim_vector(self->v)) {
-		PyErr_SetString(PyExc_SystemError, "value vectors do not support buffer protocol");
-		return -1;
-	}
-
-	*ptr = pointless_prim_vector_base_ptr(self);
-	return pointless_vector_n_bytes(self);
-}
-
-static Py_ssize_t PyPointlessVector_buffer_getsegcount(PyPointlessVector* self, Py_ssize_t* lenp)
-{
-	if (lenp)
-		*lenp = pointless_vector_n_bytes(self);
-
-	return 1;
-}
-
-static Py_ssize_t PyPointlessVector_buffer_getcharbuf(PyPointlessVector* self, Py_ssize_t index, const char** ptr)
-{
-	if (index != 0) {
-		PyErr_SetString(PyExc_SystemError, "accessing non-existent bytes segment");
-		return -1;
-	}
-
-	*ptr = pointless_prim_vector_base_ptr(self);
-	return pointless_vector_n_bytes(self);
-}
-#endif
-
 static int PyPointlessVector_getbuffer(PyPointlessVector* self, Py_buffer* view, int flags)
 {
 	if (view == 0)
@@ -620,22 +583,6 @@ static PyObject* PyPointlessVector_min(PyPointlessVector* self)
 
 static int parse_pyobject_number(PyObject* v, int* is_signed, int64_t* i, uint64_t* u)
 {
-#if PY_MAJOR_VERSION < 3
-	// simple case
-	if (PyInt_Check(v)) {
-		long _v = PyInt_AS_LONG(v);
-		if (_v < 0) {
-			*is_signed = 1;
-			*i = (int64_t)_v;
-		} else {
-			*is_signed = 0;
-			*u = (uint64_t)_v;
-		}
-
-		return 1;
-	}
-#endif
-
 	// complicated case
 	if (!PyLong_Check(v)) {
 		PyErr_SetString(PyExc_TypeError, "expected an integer");
@@ -733,30 +680,10 @@ static PyMappingMethods PyPointlessVector_as_mapping = {
 };
 
 static PyBufferProcs PyPointlessVector_as_buffer = {
-#if PY_MAJOR_VERSION < 3
-	(readbufferproc)PyPointlessVector_buffer_getreadbuf,
-	(writebufferproc)0,
-	(segcountproc)PyPointlessVector_buffer_getsegcount,
-	(charbufferproc)PyPointlessVector_buffer_getcharbuf,
-#endif
 	(getbufferproc)PyPointlessVector_getbuffer,
 	(releasebufferproc)PyPointlessVector_releasebuffer
 };
 
-#if PY_MAJOR_VERSION < 3
-static PySequenceMethods PyPointlessVector_as_sequence = {
-	(lenfunc)PyPointlessVector_length,          /* sq_length */
-	0,                                          /* sq_concat */
-	0,                                          /* sq_repeat */
-	(ssizeargfunc)PyPointlessVector_item,       /* sq_item */
-    (ssizessizeargfunc)PyPointlessVector_slice, /* sq_slice */
-	0,                                          /* sq_ass_item */
-	0,                                          /* sq_ass_slice */
-	(objobjproc)PyPointlessVector_contains,     /* sq_contains */
-	0,                                          /* sq_inplace_concat */
-	0,                                          /* sq_inplace_repeat */
-};
-#else
 static PySequenceMethods PyPointlessVector_as_sequence = {
 	(lenfunc)PyPointlessVector_length,          /* sq_length */
 	0,                                          /* sq_concat */
@@ -769,7 +696,6 @@ static PySequenceMethods PyPointlessVector_as_sequence = {
 	0,                                          /* sq_inplace_concat */
 	0,                                          /* sq_inplace_repeat */
 };
-#endif
 
 
 PyTypeObject PyPointlessVectorType = {
@@ -792,11 +718,7 @@ PyTypeObject PyPointlessVectorType = {
 	0,                                              /*tp_getattro*/
 	0,                                              /*tp_setattro*/
 	&PyPointlessVector_as_buffer,                   /*tp_as_buffer*/
-#if PY_MAJOR_VERSION < 3
-	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_NEWBUFFER, /*tp_flags*/
-#else
 	Py_TPFLAGS_DEFAULT,                             /*tp_flags*/
-#endif
 	"PyPointlessVector wrapper",                    /*tp_doc */
 	0,                                              /*tp_traverse */
 	0,                                              /*tp_clear */

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ extra_link_args = ['-L./judy-1.0.5/src', '-Bstatic', '-lJudy', '-Bdynamic', '-lm
 
 setup(
 	name='pointless',
-	version='0.3.7',
+	version='1.0.0',
 	maintainer='Arni Mar Jonsson',
 	maintainer_email='arnimarj@gmail.com',
 	url='https://github.com/arnimarj/py-pointless',


### PR DESCRIPTION
Also, move to iter semantics for map.items/keys/values and drop the iterkeys/itervalues/iteritems methods