### PR TITLE
Reversible vector iteraterators

### DIFF
--- a/pointless_ext.c
+++ b/pointless_ext.c
@@ -110,25 +110,27 @@ PyInit_pointless(void)
 	struct {
 		PyTypeObject* type;
 		const char* name;
-	} types[13] = {
-		{&PyPointlessType,               "Pointless"               },
-		{&PyPointlessVectorType,         "PointlessVector"         },
-		{&PyPointlessVectorIterType,     "PointlessVectorIter"     },
-		{&PyPointlessBitvectorType,      "PointlessBitvector"      },
-		{&PyPointlessBitvectorIterType,  "PointlessBitvectorIter"  },
-		{&PyPointlessSetType,            "PointlessSet"            },
-		{&PyPointlessSetIterType,        "PointlessSetIter"        },
-		{&PyPointlessMapType,            "PointlessMap"            },
-		{&PyPointlessMapKeyIterType,     "PointlessMapKeyIter"     },
-		{&PyPointlessMapValueIterType,   "PointlessMapValueIter"   },
-		{&PyPointlessMapItemIterType,    "PointlessMapItemIter"    },
-		{&PyPointlessPrimVectorType,     "PointlessPrimVector"     },
-		{&PyPointlessPrimVectorIterType, "PointlessPrimVectorIter" }
+	} types[15] = {
+		{&PyPointlessType,                  "Pointless"                  },
+		{&PyPointlessVectorType,            "PointlessVector"            },
+		{&PyPointlessVectorIterType,        "PointlessVectorIter"        },
+		{&PyPointlessVectorRevIterType,     "PointlessVectorRevIter"     },
+		{&PyPointlessBitvectorType,         "PointlessBitvector"         },
+		{&PyPointlessBitvectorIterType,     "PointlessBitvectorIter"     },
+		{&PyPointlessSetType,               "PointlessSet"               },
+		{&PyPointlessSetIterType,           "PointlessSetIter"           },
+		{&PyPointlessMapType,               "PointlessMap"               },
+		{&PyPointlessMapKeyIterType,        "PointlessMapKeyIter"        },
+		{&PyPointlessMapValueIterType,      "PointlessMapValueIter"      },
+		{&PyPointlessMapItemIterType,       "PointlessMapItemIter"       },
+		{&PyPointlessPrimVectorType,        "PointlessPrimVector"        },
+		{&PyPointlessPrimVectorIterType,    "PointlessPrimVectorIter"    },
+		{&PyPointlessPrimVectorRevIterType, "PointlessPrimVectorRevIter" },
 	};
 
 	int i;
 
-	for (i = 0; i < 13; i++) {
+	for (i = 0; i < 15; i++) {
 		if (PyType_Ready(types[i].type) < 0) {
 			Py_DECREF(module_pointless);
 			MODULEINITERROR;

--- a/pointless_ext.h
+++ b/pointless_ext.h
@@ -53,6 +53,12 @@ typedef struct {
 
 typedef struct {
 	PyObject_HEAD
+	PyPointlessVector* vector;
+	uint32_t iter_state;
+} PyPointlessVectorRevIter;
+
+typedef struct {
+	PyObject_HEAD
 	int is_pointless;
 	int allow_print;
 
@@ -136,6 +142,12 @@ typedef struct {
 	uint32_t iter_state;
 } PyPointlessPrimVectorIter;
 
+typedef struct {
+	PyObject_HEAD
+	PyPointlessPrimVector* vector;
+	uint32_t iter_state;
+} PyPointlessPrimVectorRevIter;
+
 PyPointlessVector* PyPointlessVector_New(PyPointless* pp, pointless_value_t* v, uint32_t slice_i, uint32_t slice_n);
 PyPointlessBitvector* PyPointlessBitvector_New(PyPointless* pp, pointless_value_t* v);
 
@@ -162,6 +174,7 @@ uint32_t pointless_pybitvector_hash_32(PyPointlessBitvector* bitvector);
 extern PyTypeObject PyPointlessType;
 extern PyTypeObject PyPointlessVectorType;
 extern PyTypeObject PyPointlessVectorIterType;
+extern PyTypeObject PyPointlessVectorRevIterType;
 extern PyTypeObject PyPointlessBitvectorType;
 extern PyTypeObject PyPointlessBitvectorIterType;
 extern PyTypeObject PyPointlessSetType;
@@ -172,6 +185,7 @@ extern PyTypeObject PyPointlessMapValueIterType;
 extern PyTypeObject PyPointlessMapItemIterType;
 extern PyTypeObject PyPointlessPrimVectorType;
 extern PyTypeObject PyPointlessPrimVectorIterType;
+extern PyTypeObject PyPointlessPrimVectorRevIterType;
 
 #define PyPointless_Check(op) PyObject_TypeCheck(op, &PyPointlessType)
 #define PyPointlessVector_Check(op) PyObject_TypeCheck(op, &PyPointlessVectorType)


### PR DESCRIPTION
This PR makes `pointless.PointlessVector` and `pointless.PointlessPrimVector` `__reversed__` iterators.This makes them so that they now finally fulfill the `collections.abc.Sequence` protocol.