### PR TITLE
fix serialization logic

### DIFF
--- a/include/pointless/pointless_create.h
+++ b/include/pointless/pointless_create.h
@@ -3,6 +3,7 @@
 
 #include <unistd.h>
 #include <assert.h>
+#include <fcntl.h>
 
 #ifndef __cplusplus
 	#include <limits.h>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.13"
+version = "1.0.14"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.7"

--- a/src/pointless_create.c
+++ b/src/pointless_create.c
@@ -1302,14 +1302,6 @@ int pointless_create_output_and_end_f(pointless_create_t* c, const char* fname, 
 
 	fd = -1;
 
-	// rename
-	if (rename(temp_fname, fname) != 0) {
-		*error = "error renaming file";
-		goto cleanup;
-	}
-
-	unlink_fname = fname;
-
 	// fclose
 	if (fclose(f) == EOF) {
 		f = 0;
@@ -1318,6 +1310,14 @@ int pointless_create_output_and_end_f(pointless_create_t* c, const char* fname, 
 	}
 
 	f = 0;
+
+	// rename
+	if (rename(temp_fname, fname) != 0) {
+		*error = "error renaming file";
+		goto cleanup;
+	}
+
+	unlink_fname = fname;
 
 	pointless_free(temp_fname);
 	temp_fname = 0;

--- a/src/pointless_create.c
+++ b/src/pointless_create.c
@@ -1288,6 +1288,14 @@ int pointless_create_output_and_end_f(pointless_create_t* c, const char* fname, 
 		goto cleanup;
 	}
 
+#ifdef __APPLE__
+	// use fcntl on MacOS
+	if (fcntl(fd, F_FULLFSYNC) != 0) {
+		*error = "fcntl F_FULLFSYNC failure";
+		goto cleanup;
+	}
+#endif
+
 	// fsync
 	if (fsync(fd) != 0) {
 		*error = "fsync failure";


### PR DESCRIPTION
We were not following the correct serialization order for atomic file creation. The order should be:

`fopen/fwrite/fflush/fclose/rename` (see https://github.com/untitaker/python-atomicwrites/blob/master/atomicwrites/__init__.py)

This PR also updates the macos build to use the `fcntl` flag `F_FULLFSYNC` in addition to `fsync`.

More reading material:

* https://danluu.com/file-consistency/
* https://blogs.gnome.org/alexl/2009/03/16/ext4-vs-fsync-my-take/
* https://www.linux.com/news/filesystems-data-preservation-fsync-and-benchmarks-pt-1/
* https://thunk.org/tytso/blog/2009/03/15/dont-fear-the-fsync/
* https://www.quora.com/When-should-you-fsync-the-containing-directory-in-addition-to-the-file-itself
* https://stackoverflow.com/questions/7433057/is-rename-without-fsync-safe
* https://www.slideshare.net/nan1nan1/eat-my-data