### PR TITLE
Feature/drop support for 32 bit offsets

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: true
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.12.0
+        run: python -m pip install cibuildwheel==2.12.1
 
       - name: Build wheels
         run: cibuildwheel --config-file pyproject.toml --output-dir wheelhouse

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,5 @@ jobs:
           (cd tests && ./compile.sh)
           pip install .
 
-          (cd tests && ./a.out --unit-test-32)
-          (cd tests && ./a.out --unit-test-64)
+          (cd tests && ./a.out --unit-test)
           PYTHONPATH=$(pwd) python -m twisted.trial tests.python_api

--- a/include/pointless/pointless_defs.h
+++ b/include/pointless/pointless_defs.h
@@ -108,8 +108,8 @@ extern "C" {
 #define POINTLESS_U64     28
 
 
-#define PC_HEAP_OFFSET(p, offsets, i) ((char*)((p)->heap_ptr) + ((p)->is_32_offset ? ((p)->offsets##_32[i]) : ((p)->offsets##_64[i])))
-#define PC_OFFSET(p, offsets, i)      (                         ((p)->is_32_offset ? ((p)->offsets##_32[i]) : ((p)->offsets##_64[i])))
+#define PC_HEAP_OFFSET(p, offsets, i) ((char*)((p)->heap_ptr) + ((p)->offsets##_64[i]))
+#define PC_OFFSET(p, offsets, i)      (                         ((p)->offsets##_64[i]))
 
 typedef union {
 	int32_t data_i32;
@@ -231,20 +231,11 @@ typedef struct {
 	pointless_header_t* header;
 
 	// offset vectors
-	uint32_t* string_unicode_offsets_32;
-	uint32_t* vector_offsets_32;
-	uint32_t* bitvector_offsets_32;
-	uint32_t* set_offsets_32;
-	uint32_t* map_offsets_32;
-
 	uint64_t* string_unicode_offsets_64;
 	uint64_t* vector_offsets_64;
 	uint64_t* bitvector_offsets_64;
 	uint64_t* set_offsets_64;
 	uint64_t* map_offsets_64;
-
-	int is_32_offset;
-	int is_64_offset;
 
 	// base heap pointer
 	void* heap_ptr;

--- a/include/pointless/pointless_recreate.h
+++ b/include/pointless/pointless_recreate.h
@@ -8,7 +8,6 @@
 
 uint32_t pointless_recreate_value(pointless_t* p_in, pointless_value_t* v_in, pointless_create_t* c_out, const char** error);
 
-int pointless_recreate_32(const char* fname_in, const char* fname_out, const char** error);
 int pointless_recreate_64(const char* fname_in, const char* fname_out, const char** error);
 
 #endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ test-command = [
     "pip install -r {package}/test-requirements.txt",
     "{package}/build_judy.sh",
     "(cd {package}/tests && ./compile.sh)",
-    "(cd {package}/tests && ./a.out --unit-test-32)",
-    "(cd {package}/tests && ./a.out --unit-test-64)",
+    "(cd {package}/tests && ./a.out --unit-test)",
     "(cd {package} && PYTHONPATH=$(pwd) python -m twisted.trial tests.python_api)",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.14"
+version = "1.0.15"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.7"

--- a/src/custom_sort.c
+++ b/src/custom_sort.c
@@ -25,7 +25,7 @@ static int med3(int a, int b, int c, qsort_cmp_ cmp, void* user)
 	return v;
 }
 
-static int bentley_qsort_priv(int a, int n, qsort_cmp_ cmp_x, qsort_swap_ swap, void* user)
+static int bentley_qsort_priv(int a, int n, qsort_cmp_ cmp, qsort_swap_ swap, void* user)
 {
 	int pm, pl, pn, pa, pb, pc, pd, i, d, r, presorted, is_error;
 
@@ -34,7 +34,7 @@ loop:
 
 	if (n < 7) {
 		for (pm = a + 1; pm < a + n; pm += 1) {
-			for (pl = pm; pl > a && cmp_adapter(pl - 1, pl, cmp_x, user, &is_error) > 0; pl -= 1) {
+			for (pl = pm; pl > a && cmp_adapter(pl - 1, pl, cmp, user, &is_error) > 0; pl -= 1) {
 				if (is_error)
 					return 0;
 
@@ -48,7 +48,7 @@ loop:
 	presorted = 1;
 
 	for (pm = a + 1; pm < a + n; pm += 1) {
-		if (cmp_adapter(pm - 1, pm, cmp_x, user, &is_error) > 0) {
+		if (cmp_adapter(pm - 1, pm, cmp, user, &is_error) > 0) {
 			if (is_error)
 				return 0;
 
@@ -68,15 +68,15 @@ loop:
 
 		if (n > 40) {
 			d = (n / 8);
-			pl = med3(pl, pl + d, pl + 2 * d, cmp_x, user);
-			pm = med3(pm - d, pm, pm + d, cmp_x, user);
-			pn = med3(pn - 2 * d, pn - d, pn, cmp_x, user);
+			pl = med3(pl, pl + d, pl + 2 * d, cmp, user);
+			pm = med3(pm - d, pm, pm + d, cmp, user);
+			pn = med3(pn - 2 * d, pn - d, pn, cmp, user);
 
 			if (pl == -1 || pm == -1 || pn == -1)
 				return 0;
 		}
 
-		pm = med3(pl, pm, pn, cmp_x, user);
+		pm = med3(pl, pm, pn, cmp, user);
 
 		if (pm == -1)
 			return 0;
@@ -88,7 +88,7 @@ loop:
 	pc = pd = a + (n - 1);
 
 	for (;;) {
-		while (pb <= pc && (r = cmp_adapter(pb, a, cmp_x, user, &is_error)) <= 0) {
+		while (pb <= pc && (r = cmp_adapter(pb, a, cmp, user, &is_error)) <= 0) {
 			if (is_error)
 				return 0;
 
@@ -100,7 +100,7 @@ loop:
 			pb += 1;
 		}
 
-		while (pb <= pc && (r = cmp_adapter(pc, a, cmp_x, user, &is_error)) >= 0) {
+		while (pb <= pc && (r = cmp_adapter(pc, a, cmp, user, &is_error)) >= 0) {
 			if (is_error)
 				return 0;
 
@@ -134,7 +134,7 @@ loop:
 		(*swap)(pb + i, pn - r + i, user);
 
 	if ((r = pb - pa) > 1) {
-		if (!bentley_qsort_priv(a, r, cmp_x, swap, user))
+		if (!bentley_qsort_priv(a, r, cmp, swap, user))
 			return 0;
 	}
 

--- a/src/pointless_create.c
+++ b/src/pointless_create.c
@@ -12,12 +12,6 @@ static size_t align_next_4_size_t(size_t v)
 	return v + lookup[v%4];
 }
 
-static uint32_t align_next_4_32(uint32_t v)
-{
-	static uint32_t lookup[4] = {0, 3, 2, 1};
-	return v + lookup[v%4];
-}
-
 static uint64_t align_next_4_64(uint64_t v)
 {
 	static uint64_t lookup[4] = {0, 3, 2, 1};
@@ -698,7 +692,6 @@ static int pointless_create_output_and_end_(pointless_create_t* c, pointless_cre
 			*error = "unsupported version";
 			return 0;
 		case POINTLESS_FF_VERSION_OFFSET_64_NEWHASH:
-			is_64_offset = 1;
 			break;
 		default:
 			*error = "unsupported version";
@@ -902,7 +895,7 @@ static int pointless_create_output_and_end_(pointless_create_t* c, pointless_cre
 	// write out offset vectors, first unicodes
 	debug_n_string_unicode = 0;
 
-	#define PC_WRITE_OFFSET() if (is_64_offset && !(*cb->write)(&current_offset_64, sizeof(current_offset_64), cb->user, error)) {goto error_cleanup;}
+	#define PC_WRITE_OFFSET() if (!(*cb->write)(&current_offset_64, sizeof(current_offset_64), cb->user, error)) {goto error_cleanup;}
 	#define PC_INCREMENT_OFFSET(f) {current_offset_64 += (f);}
 	#define PC_ALIGN_OFFSET() {current_offset_64 = align_next_4_64(current_offset_64);}
 

--- a/src/pointless_reader.c
+++ b/src/pointless_reader.c
@@ -11,15 +11,12 @@ static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int force_
 	p->header = (pointless_header_t*)buf;
 
 	// check for version
-	p->is_32_offset = 0;
-	p->is_64_offset = 0;
-
 	switch (p->header->version) {
 		case POINTLESS_FF_VERSION_OFFSET_32_OLDHASH:
 			*error = "old-hash file version not supported";
 			return 0;
 		case POINTLESS_FF_VERSION_OFFSET_32_NEWHASH:
-			p->is_32_offset = 1;
+			*error = "32-bit offset files no longer supported";
 			break;
 		case POINTLESS_FF_VERSION_OFFSET_64_NEWHASH:
 			p->is_64_offset = 1;
@@ -32,19 +29,11 @@ static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int force_
 	// right, we need some number of bytes for the offset vectors
 	uint64_t mandatory_size = sizeof(pointless_header_t);
 
-	if (p->is_32_offset) {
-		mandatory_size += p->header->n_string_unicode * sizeof(uint32_t);
-		mandatory_size += p->header->n_vector * sizeof(uint32_t);
-		mandatory_size += p->header->n_bitvector * sizeof(uint32_t);
-		mandatory_size += p->header->n_set * sizeof(uint32_t);
-		mandatory_size += p->header->n_map * sizeof(uint32_t);
-	} else {
-		mandatory_size += p->header->n_string_unicode * sizeof(uint64_t);
-		mandatory_size += p->header->n_vector * sizeof(uint64_t);
-		mandatory_size += p->header->n_bitvector * sizeof(uint64_t);
-		mandatory_size += p->header->n_set * sizeof(uint64_t);
-		mandatory_size += p->header->n_map * sizeof(uint64_t);
-	}
+	mandatory_size += p->header->n_string_unicode * sizeof(uint64_t);
+	mandatory_size += p->header->n_vector * sizeof(uint64_t);
+	mandatory_size += p->header->n_bitvector * sizeof(uint64_t);
+	mandatory_size += p->header->n_set * sizeof(uint64_t);
+	mandatory_size += p->header->n_map * sizeof(uint64_t);
 
 	if (buflen < mandatory_size) {
 		*error = "file is too small to hold offset vectors";
@@ -52,12 +41,6 @@ static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int force_
 	}
 
 	// offset vectors
-	p->string_unicode_offsets_32   = (uint32_t*)(p->header + 1);
-	p->vector_offsets_32           = (uint32_t*)(p->string_unicode_offsets_32   + p->header->n_string_unicode);
-	p->bitvector_offsets_32        = (uint32_t*)(p->vector_offsets_32           + p->header->n_vector);
-	p->set_offsets_32              = (uint32_t*)(p->bitvector_offsets_32        + p->header->n_bitvector);
-	p->map_offsets_32              = (uint32_t*)(p->set_offsets_32              + p->header->n_set);
-
 	p->string_unicode_offsets_64   = (uint64_t*)(p->header + 1);
 	p->vector_offsets_64           = (uint64_t*)(p->string_unicode_offsets_64   + p->header->n_string_unicode);
 	p->bitvector_offsets_64        = (uint64_t*)(p->vector_offsets_64           + p->header->n_vector);
@@ -66,12 +49,7 @@ static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int force_
 
 	// our heap
 	p->heap_len = (buflen - mandatory_size);
-	p->heap_ptr = 0;
-
-	if (p->is_32_offset)
-		p->heap_ptr = (void*)(p->map_offsets_32 + p->header->n_map);
-	else
-		p->heap_ptr = (void*)(p->map_offsets_64 + p->header->n_map);
+	p->heap_ptr = (void*)(p->map_offsets_64 + p->header->n_map);
 
 	// let us validate the damn thing
 	pointless_validate_context_t context;

--- a/src/pointless_reader.c
+++ b/src/pointless_reader.c
@@ -19,7 +19,6 @@ static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int force_
 			*error = "32-bit offset files no longer supported";
 			break;
 		case POINTLESS_FF_VERSION_OFFSET_64_NEWHASH:
-			p->is_64_offset = 1;
 			break;
 		default:
 			*error = "file version not supported";

--- a/src/pointless_recreate.c
+++ b/src/pointless_recreate.c
@@ -329,7 +329,7 @@ error:
 	return handle;
 }
 
-int pointless_recreate(const char* fname_in, const char* fname_out, const char** error)
+int pointless_recreate_64(const char* fname_in, const char* fname_out, const char** error)
 {
 	// open source
 	pointless_t p;
@@ -339,11 +339,7 @@ int pointless_recreate(const char* fname_in, const char* fname_out, const char**
 
 	// create destination
 	pointless_create_t c;
-
-	if (n_bits == 32)
-		pointless_create_begin_32(&c);
-	else
-		pointless_create_begin_64(&c);
+	pointless_create_begin_64(&c);
 
 	uint32_t root = pointless_recreate_value(&p, pointless_root(&p), &c, error);
 

--- a/src/pointless_recreate.c
+++ b/src/pointless_recreate.c
@@ -329,7 +329,7 @@ error:
 	return handle;
 }
 
-static int pointless_recreate_(const char* fname_in, const char* fname_out, const char** error, int n_bits)
+int pointless_recreate(const char* fname_in, const char* fname_out, const char** error)
 {
 	// open source
 	pointless_t p;
@@ -363,14 +363,4 @@ static int pointless_recreate_(const char* fname_in, const char* fname_out, cons
 
 	pointless_close(&p);
 	return 1;
-}
-
-int pointless_recreate_32(const char* fname_in, const char* fname_out, const char** error)
-{
-	return pointless_recreate_(fname_in, fname_out, error, 32);
-}
-
-int pointless_recreate_64(const char* fname_in, const char* fname_out, const char** error)
-{
-	return pointless_recreate_(fname_in, fname_out, error, 64);
 }

--- a/tests/c_api/create.c
+++ b/tests/c_api/create.c
@@ -1,13 +1,12 @@
 #include "test.h"
 
-void create_wrapper(const char* fname, create_begin_cb begin_cb, create_cb cb)
+void create_wrapper(const char* fname, create_cb cb)
 {
 	pointless_create_t c;
 	const char* error = 0;
 
 	clock_t t_0 = clock();
-
-	begin_cb(&c);
+	pointless_create_begin_64(&c);
 
 	(*cb)(&c);
 

--- a/tests/c_api/main.c
+++ b/tests/c_api/main.c
@@ -37,22 +37,12 @@ static void measure_load_time(const char* fname)
 	pointless_close(&p);
 }
 
-static void run_re_create_32(const char* fname_in, const char* fname_out)
-{
-	const char* error = 0;
-
-	if (!pointless_recreate_32(fname_in, fname_out, &error)) {
-		fprintf(stderr, "pointless_recreate_32() failure: %s\n", error);
-		exit(EXIT_FAILURE);
-	}
-}
-
-static void run_re_create_64(const char* fname_in, const char* fname_out)
+static void run_re_create(const char* fname_in, const char* fname_out)
 {
 	const char* error = 0;
 
 	if (!pointless_recreate_64(fname_in, fname_out, &error)) {
-		fprintf(stderr, "pointless_recreate_64() failure: %s\n", error);
+		fprintf(stderr, "pointless_recreate() failure: %s\n", error);
 		exit(EXIT_FAILURE);
 	}
 }
@@ -70,39 +60,39 @@ static void print_usage_exit()
 	exit(EXIT_FAILURE);
 }
 
-static void run_unit_test(create_begin_cb cb)
+static void run_unit_test()
 {
-	create_wrapper("very_simple.map", cb, create_very_simple);
+	create_wrapper("very_simple.map", create_very_simple);
 	print_map("very_simple.map");
 
-	create_wrapper("simple.map", cb, create_simple);
+	create_wrapper("simple.map", create_simple);
 	print_map("simple.map");
 
-	create_wrapper("tuple.map", cb, create_tuple);
+	create_wrapper("tuple.map", create_tuple);
 	print_map("tuple.map");
 
-	create_wrapper("set.map", cb, create_set);
+	create_wrapper("set.map", create_set);
 	query_wrapper("set.map", query_set);
 	print_map("set.map");
 
-	create_wrapper("special_a.map", cb, create_special_a);
+	create_wrapper("special_a.map", create_special_a);
 	print_map("special_a.map");
 
-	create_wrapper("special_b.map", cb, create_special_b);
+	create_wrapper("special_b.map", create_special_b);
 	print_map("special_b.map");
 
-	create_wrapper("special_c.map", cb, create_special_c);
+	create_wrapper("special_c.map", create_special_c);
 	print_map("special_c.map");
 
-	create_wrapper("special_d.map", cb, create_special_d);
+	create_wrapper("special_d.map", create_special_d);
 	print_map("special_d.map");
 	query_wrapper("special_d.map", query_special_d);
 	print_map("special_d.map");
 }
 
-static void run_performance_test(create_begin_cb cb)
+static void run_performance_test()
 {
-	create_wrapper("set_1M.map", cb, create_1M_set);
+	create_wrapper("set_1M.map", create_1M_set);
 	query_wrapper("set_1M.map", query_1M_set);
 }
 
@@ -110,9 +100,9 @@ int main(int argc, char** argv)
 {
 	if (argc == 2) {
 		if (strcmp(argv[1], "--unit-test") == 0)
-			run_unit_test(pointless_create_begin);
+			run_unit_test();
 		else if (strcmp(argv[1], "--test-performance") == 0)
-			run_performance_test(pointless_create_begin);
+			run_performance_test();
 		else if (strcmp(argv[1], "--test-hash") == 0)
 			validate_hash_semantics();
 		else

--- a/tests/c_api/main.c
+++ b/tests/c_api/main.c
@@ -61,16 +61,12 @@ static void print_usage_exit()
 {
 	fprintf(stderr, "usage: ./pointless_util OPTIONS\n");
 	fprintf(stderr, "\n");
-	fprintf(stderr, "   --unit-test-32\n");
-	fprintf(stderr, "   --unit-test-64\n");
-	fprintf(stderr, "   --test-performance-32\n");
-	fprintf(stderr, "   --test-performance-64\n");
+	fprintf(stderr, "   --unit-test\n");
+	fprintf(stderr, "   --test-performance\n");
 	fprintf(stderr, "   --measure-load-time pointless.map\n");
 	fprintf(stderr, "   --test-hash\n");
 	fprintf(stderr, "   --dump-file pointless.map\n");
-	fprintf(stderr, "   --re-create-32 pointless_in.map pointless_out.map\n");
-	fprintf(stderr, "   --re-create-64 pointless_in.map pointless_out.map\n");
-	fprintf(stderr, "   --measure-32-64-bit-difference pointless.map [...]\n");
+	fprintf(stderr, "   --re-create pointless_in.map pointless_out.map\n");
 	exit(EXIT_FAILURE);
 }
 
@@ -110,51 +106,13 @@ static void run_performance_test(create_begin_cb cb)
 	query_wrapper("set_1M.map", query_1M_set);
 }
 
-static uint64_t measure_32_64_difference(const char* fname)
-{
-	pointless_t p;
-	const char* error = 0;
-
-	if (!pointless_open_f(&p, fname, 0, &error)) {
-		fprintf(stderr, "pointless_open_f() failure: %s\n", error);
-		exit(EXIT_FAILURE);
-	}
-
-	uint64_t increase = 0;
-
-	increase += p.header->n_string_unicode;
-	increase += p.header->n_vector;
-	increase += p.header->n_bitvector;
-	increase += p.header->n_set;
-	increase += p.header->n_map;
-
-	increase *= 4;
-
-	pointless_close(&p);
-
-	return increase;
-}
-
 int main(int argc, char** argv)
 {
-	if (argc >= 3 && strcmp(argv[1], "--measure-32-64-bit-difference") == 0) {
-		int i;
-
-		uint64_t s = 0;
-
-		for (i = 2; i < argc; i++)
-			s += measure_32_64_difference(argv[i]);
-
-		printf("%llu\n", (unsigned long long)s);
-	} else if (argc == 2) {
-		if (strcmp(argv[1], "--unit-test-32") == 0)
-			run_unit_test(pointless_create_begin_32);
-		else if (strcmp(argv[1], "--unit-test-64") == 0)
-			run_unit_test(pointless_create_begin_64);
-		else if (strcmp(argv[1], "--test-performance-32") == 0)
-			run_performance_test(pointless_create_begin_32);
-		else if (strcmp(argv[1], "--test-performance-64") == 0)
-			run_performance_test(pointless_create_begin_64);
+	if (argc == 2) {
+		if (strcmp(argv[1], "--unit-test") == 0)
+			run_unit_test(pointless_create_begin);
+		else if (strcmp(argv[1], "--test-performance") == 0)
+			run_performance_test(pointless_create_begin);
 		else if (strcmp(argv[1], "--test-hash") == 0)
 			validate_hash_semantics();
 		else
@@ -168,10 +126,8 @@ int main(int argc, char** argv)
 			print_usage_exit();
 
 	} else if (argc == 4) {
-		if (strcmp(argv[1], "--re-create-32") == 0)
-			run_re_create_32(argv[2], argv[3]);
-		else if (strcmp(argv[1], "--re-create-64") == 0)
-			run_re_create_64(argv[2], argv[3]);
+		if (strcmp(argv[1], "--re-create") == 0)
+			run_re_create(argv[2], argv[3]);
 		else
 			print_usage_exit();
 	} else {

--- a/tests/c_api/test.h
+++ b/tests/c_api/test.h
@@ -15,11 +15,10 @@
 void validate_hash_semantics();
 
 // create/query test-cases
-typedef void (*create_begin_cb)(pointless_create_t* c);
 typedef void (*create_cb)(pointless_create_t* c);
 typedef void (*query_cb)(pointless_t* p);
 
-void create_wrapper(const char* fname, create_begin_cb begin_cb, create_cb cb);
+void create_wrapper(const char* fname, create_cb cb);
 void query_wrapper(const char* fname, query_cb cb);
 
 void create_tuple(pointless_create_t* c);


### PR DESCRIPTION
For a while we have supported both 32 and 64 bit offset vectors. The Python library has for a while now only created files using 64 bit offset vectors, which allow us to support fairly large files (4gb+).

There are some space savings to be had using 32-bit vectors, but they the impose limitations on the resulting file size.

The number of files using the old 32-bit file format should be very rare in the wild.