### PR TITLE
Safer pointless_value_t in Python objects

### DIFF
--- a/pointless_ext.h
+++ b/pointless_ext.h
@@ -261,7 +261,7 @@ static struct PyPointless_CAPI* PyPointless_IMPORT_CAPI(void)
 
 		if (context != (void*)POINTLESS_MAGIC_CONTEXT) {
 			Py_DECREF(c);
-			PyErr_Format(PyExc_ImportError, "invalid capsule context, was %ld, expected %ld", (long)context, (long)POINTLESS_MAGIC_CONTEXT);
+			PyErr_Format(PyExc_ImportError, "invalid capsule context, was %x, expected %x", (int)context, (int)POINTLESS_MAGIC_CONTEXT);
 			return 0;
 		}
 

--- a/pointless_ext.h
+++ b/pointless_ext.h
@@ -31,7 +31,7 @@ typedef struct {
 typedef struct {
 	PyObject_HEAD
 	PyPointless* pp;
-	pointless_value_t* v;
+	pointless_value_t v;
 	unsigned long container_id;
 	int is_hashable;
 
@@ -58,8 +58,8 @@ typedef struct {
 	int allow_print;
 
 	// pointless stuff
-	PyPointless* pointless_pp;
-	pointless_value_t* pointless_v;
+	PyPointless* pp;
+	pointless_value_t v;
 
 	// other stuff
 	uint32_t primitive_n_bits;
@@ -77,7 +77,7 @@ typedef struct {
 typedef struct {
 	PyObject_HEAD
 	PyPointless* pp;
-	pointless_value_t* v;
+	pointless_value_t v;
 	unsigned long container_id;
 } PyPointlessSet;
 
@@ -90,7 +90,7 @@ typedef struct {
 typedef struct {
 	PyObject_HEAD
 	PyPointless* pp;
-	pointless_value_t* v;
+	pointless_value_t v;
 	unsigned long container_id;
 } PyPointlessMap;
 
@@ -193,8 +193,8 @@ extern PyTypeObject PyPointlessPrimVectorRevIterType;
 PyPointlessPrimVector* PyPointlessPrimVector_from_T_vector(pointless_dynarray_t* v, uint32_t t);
 PyPointlessPrimVector* PyPointlessPrimVector_from_buffer(void* buffer, size_t n_buffer);
 
-#define POINTLESS_API_MAGIC "pointless.pointless_CAPI 1.01"
-#define POINTLESS_MAGIC_CONTEXT 0x1ABEEFFF
+#define POINTLESS_API_MAGIC "pointless.pointless_CAPI 1.02"
+#define POINTLESS_MAGIC_CONTEXT 0x1ACEEFFF
 
 struct PyPointless_CAPI {
 	// version info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.15"
+version = "1.0.16"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.7"

--- a/python/pointless_create.c
+++ b/python/pointless_create.c
@@ -144,10 +144,10 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 		PyPointlessVector* v = (PyPointlessVector*)py_object;
 		const char* error = 0;
 
-		switch(v->v->type) {
+		switch(v->v.type) {
 			case POINTLESS_VECTOR_VALUE:
 			case POINTLESS_VECTOR_VALUE_HASHABLE:
-				handle = pointless_recreate_value(&v->pp->p, v->v, &state->c, &error);
+				handle = pointless_recreate_value(&v->pp->p, &v->v, &state->c, &error);
 
 				if (handle == POINTLESS_CREATE_VALUE_FAIL) {
 					state->is_error = 1;
@@ -158,31 +158,31 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 
 				break;
 			case POINTLESS_VECTOR_I8:
-				handle = pointless_create_vector_i8_owner(&state->c, pointless_reader_vector_i8(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_i8_owner(&state->c, pointless_reader_vector_i8(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_U8:
-				handle = pointless_create_vector_u8_owner(&state->c, pointless_reader_vector_u8(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_u8_owner(&state->c, pointless_reader_vector_u8(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_I16:
-				handle = pointless_create_vector_i16_owner(&state->c, pointless_reader_vector_i16(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_i16_owner(&state->c, pointless_reader_vector_i16(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_U16:
-				handle = pointless_create_vector_u16_owner(&state->c, pointless_reader_vector_u16(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_u16_owner(&state->c, pointless_reader_vector_u16(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_I32:
-				handle = pointless_create_vector_i32_owner(&state->c, pointless_reader_vector_i32(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_i32_owner(&state->c, pointless_reader_vector_i32(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_U32:
-				handle = pointless_create_vector_u32_owner(&state->c, pointless_reader_vector_u32(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_u32_owner(&state->c, pointless_reader_vector_u32(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_I64:
-				handle = pointless_create_vector_i64_owner(&state->c, pointless_reader_vector_i64(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_i64_owner(&state->c, pointless_reader_vector_i64(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_U64:
-				handle = pointless_create_vector_u64_owner(&state->c, pointless_reader_vector_u64(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_u64_owner(&state->c, pointless_reader_vector_u64(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_FLOAT:
-				handle = pointless_create_vector_float_owner(&state->c, pointless_reader_vector_float(&v->pp->p, v->v) + v->slice_i, v->slice_n);
+				handle = pointless_create_vector_float_owner(&state->c, pointless_reader_vector_float(&v->pp->p, &v->v) + v->slice_i, v->slice_n);
 				break;
 			case POINTLESS_VECTOR_EMPTY:
 				handle = pointless_create_vector_value(&state->c);
@@ -415,7 +415,7 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 		PyPointlessBitvector* bitvector = (PyPointlessBitvector*)py_object;
 
 		if (bitvector->is_pointless) {
-			uint32_t i, n_bits = pointless_reader_bitvector_n_bits(&bitvector->pointless_pp->p, bitvector->pointless_v);
+			uint32_t i, n_bits = pointless_reader_bitvector_n_bits(&bitvector->pp->p, &bitvector->v);
 			void* bits = pointless_calloc(ICEIL(n_bits, 8), 1);
 
 			if (bits == 0) {
@@ -423,7 +423,7 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 			}
 
 			for (i = 0; i < n_bits; i++) {
-				if (pointless_reader_bitvector_is_set(&bitvector->pointless_pp->p, bitvector->pointless_v, i))
+				if (pointless_reader_bitvector_is_set(&bitvector->pp->p, &bitvector->v, i))
 					bm_set_(bits, i);
 			}
 
@@ -450,7 +450,7 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 	} else if (PyPointlessSet_Check(py_object)) {
 		PyPointlessSet* set = (PyPointlessSet*)py_object;
 		const char* error = 0;
-		handle = pointless_recreate_value(&set->pp->p, set->v, &state->c, &error);
+		handle = pointless_recreate_value(&set->pp->p, &set->v, &state->c, &error);
 
 		if (handle == POINTLESS_CREATE_VALUE_FAIL) {
 			state->is_error = 1;
@@ -466,7 +466,7 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 	} else if (PyPointlessMap_Check(py_object)) {
 		PyPointlessMap* map = (PyPointlessMap*)py_object;
 		const char* error = 0;
-		handle = pointless_recreate_value(&map->pp->p, map->v, &state->c, &error);
+		handle = pointless_recreate_value(&map->pp->p, &map->v, &state->c, &error);
 
 		if (handle == POINTLESS_CREATE_VALUE_FAIL) {
 			state->is_error = 1;

--- a/python/pointless_map.c
+++ b/python/pointless_map.c
@@ -8,7 +8,6 @@ static void PyPointlessMap_dealloc(PyPointlessMap* self)
 	}
 
 	self->pp = 0;
-	self->v = 0;
 	self->container_id = 0;
 	Py_TYPE(self)->tp_free(self);
 }
@@ -43,7 +42,6 @@ PyObject* PyPointlessMap_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 
 	if (self) {
 		self->pp = 0;
-		self->v = 0;
 		self->container_id = 0;
 	}
 
@@ -112,7 +110,7 @@ static int PyPointlessMapItemIter_init(PyPointlessMap* self, PyObject* args)
 
 static Py_ssize_t PyPointlessMap_length(PyPointlessSet* self)
 {
-	return (Py_ssize_t)pointless_reader_map_n_items(&self->pp->p, self->v);
+	return (Py_ssize_t)pointless_reader_map_n_items(&self->pp->p, &self->v);
 }
 
 static PyObject* PyPointlessMap_iter(PyObject* map)
@@ -144,7 +142,7 @@ static PyObject* PyPointlessMapKeyIter_iternext(PyPointlessMapKeyIter* iter)
 	pointless_value_t* k = 0;
 	pointless_value_t* v = 0;
 
-	if (pointless_reader_map_iter(&iter->map->pp->p, iter->map->v, &k, &v, &iter->iter_state))
+	if (pointless_reader_map_iter(&iter->map->pp->p, &iter->map->v, &k, &v, &iter->iter_state))
 		return pypointless_value(iter->map->pp, k);
 
 	Py_DECREF(iter->map);
@@ -161,7 +159,7 @@ static PyObject* PyPointlessMapValueIter_iternext(PyPointlessMapValueIter* iter)
 	pointless_value_t* k = 0;
 	pointless_value_t* v = 0;
 
-	if (pointless_reader_map_iter(&iter->map->pp->p, iter->map->v, &k, &v, &iter->iter_state))
+	if (pointless_reader_map_iter(&iter->map->pp->p, &iter->map->v, &k, &v, &iter->iter_state))
 		return pypointless_value(iter->map->pp, v);
 
 	Py_DECREF(iter->map);
@@ -178,7 +176,7 @@ static PyObject* PyPointlessMapItemIter_iternext(PyPointlessMapItemIter* iter)
 	pointless_value_t* k = 0;
 	pointless_value_t* v = 0;
 
-	if (pointless_reader_map_iter(&iter->map->pp->p, iter->map->v, &k, &v, &iter->iter_state)) {
+	if (pointless_reader_map_iter(&iter->map->pp->p, &iter->map->v, &k, &v, &iter->iter_state)) {
 		PyObject* kk = pypointless_value(iter->map->pp, k);
 		PyObject* vv = pypointless_value(iter->map->pp, v);
 
@@ -214,7 +212,7 @@ static int PyPointlessMap_contains_(PyPointlessMap* m, PyObject* key)
 	pointless_value_t* k = 0;
 	pointless_value_t* v = 0;
 
-	pointless_reader_map_lookup_ext(&m->pp->p, m->v, hash, PyPointlessMap_eq_cb, (void*)key, &k, &v, &error);
+	pointless_reader_map_lookup_ext(&m->pp->p, &m->v, hash, PyPointlessMap_eq_cb, (void*)key, &k, &v, &error);
 
 	if (error) {
 		PyErr_Format(PyExc_ValueError, "pointless map query error: %s", error);
@@ -294,7 +292,7 @@ static PyObject* PyPointlessMap_subscript(PyPointlessMap* m, PyObject* key)
 	pointless_value_t* k = 0;
 	pointless_value_t* v = 0;
 
-	pointless_reader_map_lookup_ext(&m->pp->p, m->v, hash, PyPointlessMap_eq_cb, (void*)key, &k, &v, &error);
+	pointless_reader_map_lookup_ext(&m->pp->p, &m->v, hash, PyPointlessMap_eq_cb, (void*)key, &k, &v, &error);
 
 	if (error) {
 		PyErr_Format(PyExc_ValueError, "pointless map query error: %s", error);
@@ -334,7 +332,7 @@ static PyObject* PyPointlessMap_get(PyPointlessMap* m, PyObject* args)
 	pointless_value_t* k = 0;
 	pointless_value_t* v = 0;
 
-	pointless_reader_map_lookup_ext(&m->pp->p, m->v, hash, PyPointlessMap_eq_cb, (void*)key, &k, &v, &error);
+	pointless_reader_map_lookup_ext(&m->pp->p, &m->v, hash, PyPointlessMap_eq_cb, (void*)key, &k, &v, &error);
 
 	if (error) {
 		PyErr_Format(PyExc_ValueError, "pointless map query error: %s", error);
@@ -545,7 +543,7 @@ PyPointlessMap* PyPointlessMap_New(PyPointless* pp, pointless_value_t* v)
 	Py_INCREF(pp);
 	pp->n_map_refs += 1;
 	pv->pp = pp;
-	pv->v = v;
+	pv->v = *v;
 
 	// the container ID is a unique between all non-empty vectors, maps and sets
 	pv->container_id = pointless_container_id(&pp->p, v);

--- a/python/pointless_prim_vector.c
+++ b/python/pointless_prim_vector.c
@@ -782,55 +782,55 @@ static PyObject* PyPointlessPrimVector_append_bulk(PyPointlessPrimVector* self, 
 		PyPointlessVector* p_obj = (PyPointlessVector*)obj;
 		size_t s = 0;
 
-		if      (p_obj->v->type == POINTLESS_VECTOR_I8 && self->type == POINTLESS_PRIM_VECTOR_TYPE_I8)
+		if      (p_obj->v.type == POINTLESS_VECTOR_I8 && self->type == POINTLESS_PRIM_VECTOR_TYPE_I8)
 			s = sizeof(int8_t);
-		else if (p_obj->v->type == POINTLESS_VECTOR_U8 && self->type == POINTLESS_PRIM_VECTOR_TYPE_U8)
+		else if (p_obj->v.type == POINTLESS_VECTOR_U8 && self->type == POINTLESS_PRIM_VECTOR_TYPE_U8)
 			s = sizeof(uint8_t);
-		else if (p_obj->v->type == POINTLESS_VECTOR_I16 && self->type == POINTLESS_PRIM_VECTOR_TYPE_I16)
+		else if (p_obj->v.type == POINTLESS_VECTOR_I16 && self->type == POINTLESS_PRIM_VECTOR_TYPE_I16)
 			s = sizeof(int16_t);
-		else if (p_obj->v->type == POINTLESS_VECTOR_U16 && self->type == POINTLESS_PRIM_VECTOR_TYPE_U16)
+		else if (p_obj->v.type == POINTLESS_VECTOR_U16 && self->type == POINTLESS_PRIM_VECTOR_TYPE_U16)
 			s = sizeof(uint16_t);
-		else if (p_obj->v->type == POINTLESS_VECTOR_I32 && self->type == POINTLESS_PRIM_VECTOR_TYPE_I32)
+		else if (p_obj->v.type == POINTLESS_VECTOR_I32 && self->type == POINTLESS_PRIM_VECTOR_TYPE_I32)
 			s = sizeof(int32_t);
-		else if (p_obj->v->type == POINTLESS_VECTOR_U32 && self->type == POINTLESS_PRIM_VECTOR_TYPE_U32)
+		else if (p_obj->v.type == POINTLESS_VECTOR_U32 && self->type == POINTLESS_PRIM_VECTOR_TYPE_U32)
 			s = sizeof(uint32_t);
-		else if (p_obj->v->type == POINTLESS_VECTOR_I64 && self->type == POINTLESS_PRIM_VECTOR_TYPE_I64)
+		else if (p_obj->v.type == POINTLESS_VECTOR_I64 && self->type == POINTLESS_PRIM_VECTOR_TYPE_I64)
 			s = sizeof(int64_t);
-		else if (p_obj->v->type == POINTLESS_VECTOR_U64 && self->type == POINTLESS_PRIM_VECTOR_TYPE_U64)
+		else if (p_obj->v.type == POINTLESS_VECTOR_U64 && self->type == POINTLESS_PRIM_VECTOR_TYPE_U64)
 			s = sizeof(uint64_t);
-		else if (p_obj->v->type == POINTLESS_VECTOR_FLOAT && self->type == POINTLESS_PRIM_VECTOR_TYPE_FLOAT)
+		else if (p_obj->v.type == POINTLESS_VECTOR_FLOAT && self->type == POINTLESS_PRIM_VECTOR_TYPE_FLOAT)
 			s = sizeof(float);
 
 		if (s > 0) {
 			void* base = 0;
 
-			switch (p_obj->v->type) {
+			switch (p_obj->v.type) {
 				case POINTLESS_VECTOR_I8:
-					base = pointless_reader_vector_i8(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_i8(&p_obj->pp->p, &p_obj->v);
 					break;
 				case POINTLESS_VECTOR_U8:
-					base = pointless_reader_vector_u8(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_u8(&p_obj->pp->p, &p_obj->v);
 					break;
 				case POINTLESS_VECTOR_I16:
-					base = pointless_reader_vector_i16(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_i16(&p_obj->pp->p, &p_obj->v);
 					break;
 				case POINTLESS_VECTOR_U16:
-					base = pointless_reader_vector_u16(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_u16(&p_obj->pp->p, &p_obj->v);
 					break;
 				case POINTLESS_VECTOR_I32:
-					base = pointless_reader_vector_i32(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_i32(&p_obj->pp->p, &p_obj->v);
 					break;
 				case POINTLESS_VECTOR_U32:
-					base = pointless_reader_vector_u32(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_u32(&p_obj->pp->p, &p_obj->v);
 					break;
 				case POINTLESS_VECTOR_I64:
-					base = pointless_reader_vector_i64(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_i64(&p_obj->pp->p, &p_obj->v);
 					break;
 				case POINTLESS_VECTOR_U64:
-					base = pointless_reader_vector_u64(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_u64(&p_obj->pp->p, &p_obj->v);
 					break;
 				case POINTLESS_VECTOR_FLOAT:
-					base = pointless_reader_vector_float(&p_obj->pp->p, p_obj->v);
+					base = pointless_reader_vector_float(&p_obj->pp->p, &p_obj->v);
 					break;
 			}
 
@@ -1014,7 +1014,7 @@ static size_t PyPointlessPrimVector_index_(PyPointlessPrimVector* self, PyObject
 
 	if (self->type == POINTLESS_PRIM_VECTOR_TYPE_FLOAT) {
 		float ff;
-	
+
 		if (!PyArg_ParseTuple(args, "f", &ff))
 			return (SIZE_MAX-1);
 
@@ -1489,44 +1489,44 @@ static PyObject* PyPointlessPrimVector_sort_proj(PyPointlessPrimVector* self, Py
 			PyPointlessVector* pv = (PyPointlessVector*)state.v_p[state.n];
 
 			state.v_n[state.n] = pv->slice_n;
-			state.v_t[state.n] = pv->v->type;
+			state.v_t[state.n] = pv->v.type;
 
-			switch (pv->v->type) {
+			switch (pv->v.type) {
 				// we only want primitive types, or empty vectors
 				case POINTLESS_VECTOR_I8:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_i8(&pv->pp->p, pv->v)    + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_i8(&pv->pp->p, &pv->v)    + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_i8;
 					break;
 				case POINTLESS_VECTOR_U8:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_u8(&pv->pp->p, pv->v)    + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_u8(&pv->pp->p, &pv->v)    + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_u8;
 					break;
 				case POINTLESS_VECTOR_I16:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_i16(&pv->pp->p, pv->v)   + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_i16(&pv->pp->p, &pv->v)   + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_i16;
 					break;
 				case POINTLESS_VECTOR_U16:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_u16(&pv->pp->p, pv->v)   + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_u16(&pv->pp->p, &pv->v)   + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_u16;
 					break;
 				case POINTLESS_VECTOR_I32:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_i32(&pv->pp->p, pv->v)   + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_i32(&pv->pp->p, &pv->v)   + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_i32;
 					break;
 				case POINTLESS_VECTOR_U32:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_u32(&pv->pp->p, pv->v)   + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_u32(&pv->pp->p, &pv->v)   + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_u32;
 					break;
 				case POINTLESS_VECTOR_I64:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_i64(&pv->pp->p, pv->v)   + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_i64(&pv->pp->p, &pv->v)   + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_i64;
 					break;
 				case POINTLESS_VECTOR_U64:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_u64(&pv->pp->p, pv->v)   + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_u64(&pv->pp->p, &pv->v)   + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_u64;
 					break;
 				case POINTLESS_VECTOR_FLOAT:
-					state.v_b[state.n] = (void*)(pointless_reader_vector_float(&pv->pp->p, pv->v) + pv->slice_i);
+					state.v_b[state.n] = (void*)(pointless_reader_vector_float(&pv->pp->p, &pv->v) + pv->slice_i);
 					state.cmp_cmp[state.n] = prim_sort_proj_cmp_cmp_f;
 					break;
 				case POINTLESS_VECTOR_EMPTY:
@@ -1714,18 +1714,18 @@ static int PyPointlessPrimVector_from_remap_index_vector_pointless(PyPointlessVe
 	int64_t n_i = 0;
 	int is_i = 1;
 
-	switch (v_->v->type) {
+	switch (v_->v.type) {
 		case POINTLESS_VECTOR_I8:
-			n_i = (int64_t)(*(pointless_reader_vector_i8(&v_->pp->p, v_->v) + i));
+			n_i = (int64_t)(*(pointless_reader_vector_i8(&v_->pp->p, &v_->v) + i));
 			break;
 		case POINTLESS_VECTOR_I16:
-			n_i = (int64_t)(*(pointless_reader_vector_i16(&v_->pp->p, v_->v) + i));
+			n_i = (int64_t)(*(pointless_reader_vector_i16(&v_->pp->p, &v_->v) + i));
 			break;
 		case POINTLESS_VECTOR_I32:
-			n_i = (int64_t)(*(pointless_reader_vector_i32(&v_->pp->p, v_->v) + i));
+			n_i = (int64_t)(*(pointless_reader_vector_i32(&v_->pp->p, &v_->v) + i));
 			break;
 		case POINTLESS_VECTOR_I64:
-			n_i = (int64_t)(*(pointless_reader_vector_i64(&v_->pp->p, v_->v) + i));
+			n_i = (int64_t)(*(pointless_reader_vector_i64(&v_->pp->p, &v_->v) + i));
 			break;
 		default:
 			is_i = 0;
@@ -1739,18 +1739,18 @@ static int PyPointlessPrimVector_from_remap_index_vector_pointless(PyPointlessVe
 		return 1;
 	}
 
-	switch (v_->v->type) {
+	switch (v_->v.type) {
 		case POINTLESS_VECTOR_U8:
-			n_u = (uint64_t)(*(pointless_reader_vector_u8(&v_->pp->p, v_->v) + i));
+			n_u = (uint64_t)(*(pointless_reader_vector_u8(&v_->pp->p, &v_->v) + i));
 			break;
 		case POINTLESS_VECTOR_U16:
-			n_u = (uint64_t)(*(pointless_reader_vector_u16(&v_->pp->p, v_->v) + i));
+			n_u = (uint64_t)(*(pointless_reader_vector_u16(&v_->pp->p, &v_->v) + i));
 			break;
 		case POINTLESS_VECTOR_U32:
-			n_u = (uint64_t)(*(pointless_reader_vector_u32(&v_->pp->p, v_->v) + i));
+			n_u = (uint64_t)(*(pointless_reader_vector_u32(&v_->pp->p, &v_->v) + i));
 			break;
 		case POINTLESS_VECTOR_U64:
-			n_u = (uint64_t)(*(pointless_reader_vector_u64(&v_->pp->p, v_->v) + i));
+			n_u = (uint64_t)(*(pointless_reader_vector_u64(&v_->pp->p, &v_->v) + i));
 			break;
 		default:
 			return 0;

--- a/python/pointless_print.c
+++ b/python/pointless_print.c
@@ -450,14 +450,14 @@ PyObject* PyPointless_str(PyObject* py_object)
 
 	// the pointless handle and pointless value
 	PyPointless* pp = 0;
-	pointless_value_t* v = 0;
+	pointless_value_t v;
 	uint32_t vector_slice_i = 0;
 	uint32_t vector_slice_n = 0;
 
 	if (PyPointlessBitvector_Check(py_object)) {
 		PyPointlessBitvector* b = (PyPointlessBitvector*)py_object;
-		pp = b->pointless_pp;
-		v = b->pointless_v;
+		pp = b->pp;
+		v = b->v;
 	} else if (PyPointlessVector_Check(py_object)) {
 		PyPointlessVector* vector = (PyPointlessVector*)py_object;
 		pp = vector->pp;
@@ -483,7 +483,7 @@ PyObject* PyPointless_str(PyObject* py_object)
 		return PyUnicode_FromFormat("<%s object at %p>", Py_TYPE(py_object)->tp_name, (void*)py_object);
 	}
 
-	pointless_complete_value_t _v = pointless_value_to_complete(v);
+	pointless_complete_value_t _v = pointless_value_to_complete(&v);
 	int i = _pypointless_str_rec(&pp->p, &_v, &state, vector_slice_i, vector_slice_n, 0);
 	PyObject* s = 0;
 

--- a/python/pointless_pyobject_cmp.c
+++ b/python/pointless_pyobject_cmp.c
@@ -33,53 +33,6 @@ typedef struct {
 	float ff;
 } pypointless_cmp_int_float_bool_t;
 
-static const char* _type_name(uint32_t type)
-{
-	switch (type) {
-		case POINTLESS_VECTOR_VALUE:
-		case POINTLESS_VECTOR_VALUE_HASHABLE:
-		case POINTLESS_VECTOR_I8:
-		case POINTLESS_VECTOR_U8:
-		case POINTLESS_VECTOR_I16:
-		case POINTLESS_VECTOR_U16:
-		case POINTLESS_VECTOR_I32:
-		case POINTLESS_VECTOR_U32:
-		case POINTLESS_VECTOR_I64:
-		case POINTLESS_VECTOR_U64:
-		case POINTLESS_VECTOR_FLOAT:
-		case POINTLESS_VECTOR_EMPTY:
-			return "pointless.PyPointlessVector";
-		case POINTLESS_UNICODE_:
-			return "unicode";
-		case POINTLESS_STRING_:
-			return "str";
-		case POINTLESS_BITVECTOR:
-		case POINTLESS_BITVECTOR_0:
-		case POINTLESS_BITVECTOR_1:
-		case POINTLESS_BITVECTOR_01:
-		case POINTLESS_BITVECTOR_10:
-		case POINTLESS_BITVECTOR_PACKED:
-			return "pointless.PyPointlessBitvector";
-		case POINTLESS_SET_VALUE:
-			return "pointless.PyPointlessSet";
-		case POINTLESS_MAP_VALUE_VALUE:
-			return "pointless.PyPointlessMap";
-		case POINTLESS_I32:
-		case POINTLESS_U32:
-		case POINTLESS_FLOAT:
-			return "";
-		case POINTLESS_BOOLEAN:
-			return "bool";
-		case POINTLESS_NULL:
-			return "NoneType";
-		case POINTLESS_I64:
-		case POINTLESS_U64:
-			return "";
-	}
-
-	return "";
-}
-
 static void pypointless_cmp_value_init_pointless(pypointless_cmp_value_t* cv, pointless_t* p, pointless_complete_value_t* v)
 {
 	cv->is_pointless = 1;
@@ -103,21 +56,21 @@ static void pypointless_cmp_value_init_python(pypointless_cmp_value_t* v, PyObje
 	if (PyPointlessVector_Check(py_object)) {
 		v->is_pointless = 1;
 		v->value.pointless.p = &(((PyPointlessVector*)py_object)->pp->p);
-		v->value.pointless.v = pointless_value_to_complete((((PyPointlessVector*)py_object)->v));
+		v->value.pointless.v = pointless_value_to_complete(&(((PyPointlessVector*)py_object)->v));
 		v->value.pointless.vector_slice_i = ((PyPointlessVector*)py_object)->slice_i;
 		v->value.pointless.vector_slice_n = ((PyPointlessVector*)py_object)->slice_n;
 	} else if (PyPointlessBitvector_Check(py_object) && ((PyPointlessBitvector*)py_object)->is_pointless) {
 		v->is_pointless = 1;
-		v->value.pointless.p = &(((PyPointlessBitvector*)py_object)->pointless_pp->p);
-		v->value.pointless.v = pointless_value_to_complete((((PyPointlessBitvector*)py_object)->pointless_v));
+		v->value.pointless.p = &(((PyPointlessBitvector*)py_object)->pp->p);
+		v->value.pointless.v = pointless_value_to_complete(&(((PyPointlessBitvector*)py_object)->v));
 	} else if (PyPointlessSet_Check(py_object)) {
 		v->is_pointless = 1;
 		v->value.pointless.p = &(((PyPointlessSet*)py_object)->pp->p);
-		v->value.pointless.v = pointless_value_to_complete((((PyPointlessSet*)py_object)->v));
+		v->value.pointless.v = pointless_value_to_complete(&(((PyPointlessSet*)py_object)->v));
 	} else if (PyPointlessMap_Check(py_object)) {
 		v->is_pointless = 1;
 		v->value.pointless.p = &(((PyPointlessMap*)py_object)->pp->p);
-		v->value.pointless.v = pointless_value_to_complete((((PyPointlessMap*)py_object)->v));
+		v->value.pointless.v = pointless_value_to_complete(&(((PyPointlessMap*)py_object)->v));
 	} else {
 		v->is_pointless = 0;
 		v->value.py_object = py_object;
@@ -540,7 +493,7 @@ static uint32_t pypointless_cmp_bitvector_n_items(pypointless_cmp_value_t* v)
 	PyPointlessBitvector* bv = (PyPointlessBitvector*)v->value.py_object;
 
 	if (bv->is_pointless)
-		return pointless_reader_bitvector_n_bits(&bv->pointless_pp->p, bv->pointless_v);
+		return pointless_reader_bitvector_n_bits(&bv->pp->p, &bv->v);
 
 	return bv->primitive_n_bits;
 }
@@ -557,7 +510,7 @@ static uint32_t pypointless_cmp_bitvector_item_at(pypointless_cmp_value_t* v, ui
 	PyPointlessBitvector* bv = (PyPointlessBitvector*)v->value.py_object;
 
 	if (bv->is_pointless)
-		return pointless_reader_bitvector_is_set(&bv->pointless_pp->p, bv->pointless_v, i);
+		return pointless_reader_bitvector_is_set(&bv->pp->p, &bv->v, i);
 
 	return (bm_is_set_(bv->primitive_bits, i) != 0);
 }

--- a/python/pointless_pyobject_hash.c
+++ b/python/pointless_pyobject_hash.c
@@ -217,18 +217,18 @@ static uint32_t pyobject_hash_rec_32(PyObject* py_object, pyobject_hash_state_t*
 
 	// pointless types
 	pointless_t* p = 0;
-	pointless_value_t* v = 0;
+	pointless_value_t v;
 
 	if (PyPointlessVector_Check(py_object)) {
 		p = &((PyPointlessVector*)py_object)->pp->p;
 		v = ((PyPointlessVector*)py_object)->v;
 
-		if (!pointless_is_hashable(v->type)) {
+		if (!pointless_is_hashable(v.type)) {
 			*state->error = "pointless type is not hashable";
 			return 0;
 		}
 
-		return pointless_hash_reader_vector_32(p, v, ((PyPointlessVector*)py_object)->slice_i, ((PyPointlessVector*)py_object)->slice_n);
+		return pointless_hash_reader_vector_32(p, &v, ((PyPointlessVector*)py_object)->slice_i, ((PyPointlessVector*)py_object)->slice_n);
 	}
 
 	if (PyPointlessBitvector_Check(py_object))
@@ -238,12 +238,12 @@ static uint32_t pyobject_hash_rec_32(PyObject* py_object, pyobject_hash_state_t*
 		p = &((PyPointlessSet*)py_object)->pp->p;
 		v = ((PyPointlessSet*)py_object)->v;
 
-		if (!pointless_is_hashable(v->type)) {
+		if (!pointless_is_hashable(v.type)) {
 			*state->error = "pointless type is not hashable";
 			return 0;
 		}
 
-		return pointless_hash_reader_32(p, v);
+		return pointless_hash_reader_32(p, &v);
 	}
 
 	// prim-vector

--- a/python/pointless_set.c
+++ b/python/pointless_set.c
@@ -8,7 +8,6 @@ static void PyPointlessSet_dealloc(PyPointlessSet* self)
 	}
 
 	self->pp = 0;
-	self->v = 0;
 	self->container_id = 0;
 	Py_TYPE(self)->tp_free(self);
 }
@@ -27,7 +26,6 @@ PyObject* PyPointlessSet_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 
 	if (self) {
 		self->pp = 0;
-		self->v = 0;
 		self->container_id = 0;
 	}
 
@@ -48,7 +46,7 @@ PyObject* PyPointlessSetIter_new(PyTypeObject* type, PyObject* args, PyObject* k
 
 static Py_ssize_t PyPointlessSet_length(PyPointlessSet* self)
 {
-	return (Py_ssize_t)pointless_reader_set_n_items(&self->pp->p, self->v);
+	return (Py_ssize_t)pointless_reader_set_n_items(&self->pp->p, &self->v);
 }
 
 static PyObject* PyPointlessSet_iter(PyObject* set)
@@ -79,7 +77,7 @@ static PyObject* PyPointlessSetIter_iternext(PyPointlessSetIter* iter)
 
 	pointless_value_t* v = 0;
 
-	if (pointless_reader_set_iter(&iter->set->pp->p, iter->set->v, &v, &iter->iter_state))
+	if (pointless_reader_set_iter(&iter->set->pp->p, &iter->set->v, &v, &iter->iter_state))
 		return pypointless_value(iter->set->pp, v);
 
 	Py_DECREF(iter->set);
@@ -103,7 +101,7 @@ static int PyPointlessSet_contains(PyPointlessSet* s, PyObject* key)
 	}
 
 	pointless_value_t* kk = 0;
-	pointless_reader_set_lookup_ext(&s->pp->p, s->v, hash, PyPointlessSet_eq_cb, (void*)key, &kk, &error);
+	pointless_reader_set_lookup_ext(&s->pp->p, &s->v, hash, PyPointlessSet_eq_cb, (void*)key, &kk, &error);
 
 	if (error) {
 		PyErr_Format(PyExc_ValueError, "pointless set query error: %s", error);
@@ -229,7 +227,7 @@ PyPointlessSet* PyPointlessSet_New(PyPointless* pp, pointless_value_t* v)
 	pp->n_set_refs += 1;
 
 	pv->pp = pp;
-	pv->v = v;
+	pv->v = *v;
 
 	// the container ID is a unique between all non-empty vectors, maps and sets
 	pv->container_id = pointless_container_id(&pp->p, v);

--- a/src/pointless_eval.c
+++ b/src/pointless_eval.c
@@ -96,7 +96,7 @@ static const char* pointless_eval_get_single(pointless_t* p, pointless_value_t* 
 			break;
 		// placeholder value
 		case '%':
-			// %u64, %u32, %i64, %i32, 
+			// %u64, %u32, %i64, %i32,
 			e += 1;
 			if (*e == 'u') {
 				is_unsigned = 1;

--- a/src/pointless_recreate.c
+++ b/src/pointless_recreate.c
@@ -189,7 +189,7 @@ static uint32_t pointless_recreate_convert_rec(pointless_recreate_state_t* state
 			if (handle == POINTLESS_CREATE_VALUE_FAIL)
 				*state->error = "out of memory";
 			return handle;
-	
+
 		case POINTLESS_BITVECTOR:
 			n_bits = pointless_reader_bitvector_n_bits(state->p, v);
 			bits = pointless_calloc(ICEIL(n_bits, 8), 1);

--- a/src/pointless_validate.c
+++ b/src/pointless_validate.c
@@ -114,7 +114,7 @@ static uint32_t pointless_validate_pass_cb(pointless_t* p, pointless_value_t* v,
 
 			if (bm_is_set_(state->cycle_marker, container_id)) {
 				state->error = "POINTLESS_VECTOR_VALUE_HASHABLE is in a cycle";
-				return POINTLESS_WALK_STOP; 
+				return POINTLESS_WALK_STOP;
 			}
 		}
 	// pass-3, hash test

--- a/src/pointless_validate_heap.c
+++ b/src/pointless_validate_heap.c
@@ -165,7 +165,7 @@ static int32_t pointless_validate_string_heap(pointless_validate_context_t* cont
 	}
 
 	if (s[i] != 0) {
-		*error = "missing end-of-string";	
+		*error = "missing end-of-string";
 		return 0;
 	}
 

--- a/tests/c_api/create.c
+++ b/tests/c_api/create.c
@@ -172,7 +172,7 @@ void query_set(pointless_t* p)
 
 		if (kk == 0) {
 			fprintf(stderr, "set does not contain the expected value\n");
-			exit(EXIT_FAILURE);	
+			exit(EXIT_FAILURE);
 		}
 
 		// they must be equal

--- a/tests/c_api/performance_test.c
+++ b/tests/c_api/performance_test.c
@@ -73,7 +73,7 @@ void query_1M_set(pointless_t* p)
 
 		if (kk == 0) {
 			fprintf(stderr, "query_1M_set(): set does not contain the expected value\n");
-			exit(EXIT_FAILURE);	
+			exit(EXIT_FAILURE);
 		}
 	}
 }

--- a/tests/python_api/test_set_map.py
+++ b/tests/python_api/test_set_map.py
@@ -75,7 +75,7 @@ class TestSetMap(unittest.TestCase):
 				1: 2,
 				2: 3,
 				4: 4,
-				'asdf': 123, 
+				'asdf': 123,
 				(1,2): [4,5,'hello world']
 			}
 		]
@@ -150,7 +150,7 @@ class TestSetMap(unittest.TestCase):
 				pointless.serialize(ii, fname_c)
 				root_c = pointless.Pointless(fname_c).GetRoot()
 
-				# element <- A, C <- A, B <- A, 
+				# element <- A, C <- A, B <- A,
 				self.assert_(ii in root_a)
 				self.assert_(root_c in root_a)
 				self.assert_(root_b in root_a)


### PR DESCRIPTION
The C-based Python objects which wrap the code for the various types had a serious weakness.

Each such object (including `PyPointlessBitvector`, `PyPointlessSet`, `PyPointlessVector` and `PyPointlessMap`) stored two pointers:

1. the `PyPointless` object owning the `pointless_t` object and the `mmap`'d data
2. the actual value, a `pointless_value_t` stored as a pointer.

For almost all values stored in a pointless file,there is a corresponding `pointless_value_t`  for that in the `mmap` itself. That meant that holding a pointer to the `pointless_value_t` was perfectly safe, since the lifetime of the mmap was tied to the lifetime of the object itself (since itself held a reference to the `PyPointlessObject`.

The problem with this approach is when using `pointless` from another C-Extension. In particular the `create_pypointless_value` function (available via the Capsule API)  will assume that the passed in pointer of `pointless_value_t` is itself part of the `mmap`.

That can go disastrously wrong, and is a difficult contract for the calling code to remember.

So this change simply embeds the `pointless_value_t` into the object structs making such pointer lifetime issues moot.

We need to bump the ABI value, meaning that any C extensions using the capsule API need to be updated should they want to use this new version.