### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,13 +22,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           submodules: true
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.12.1
+        run: python -m pip install cibuildwheel==2.15.1
 
       - name: Build wheels
         run: cibuildwheel --config-file pyproject.toml --output-dir wheelhouse

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: true
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.15.1
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Build wheels
         run: cibuildwheel --config-file pyproject.toml --output-dir wheelhouse

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12, ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12.0-rc.2']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12, ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12.0-rc.2']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           submodules: true

--- a/include/pointless/pointless_defs.h
+++ b/include/pointless/pointless_defs.h
@@ -48,11 +48,6 @@ extern "C" {
     enum { ASSERT_CONCAT(assert_line_, __LINE__) = 1/(!!(e)) }
 #endif
 
-// POINTLESS_WCHAR_T_IS_4_BYTES
-#if 2147483647 <= WCHAR_MAX && WCHAR_MAX <= 4294967295
-#define POINTLESS_WCHAR_T_IS_4_BYTES
-#endif
-
 // we use 32-bits for unicodes, and 8-bits for those who can
 #define pointless_string_char_t uint8_t
 #define pointless_unicode_char_t uint32_t
@@ -403,10 +398,6 @@ uint32_t pointless_hash_reader_vector_32(pointless_t* p, pointless_value_t* v, u
 uint32_t pointless_hash_create_32(pointless_create_t* c, pointless_create_value_t* v);
 
 // comparison functions
-#ifdef POINTLESS_WCHAR_T_IS_4_BYTES
-int32_t pointless_cmp_wchar_wchar(wchar_t* a, wchar_t* b);
-#endif
-
 int32_t pointless_cmp_string_8_8(uint8_t* a, uint8_t* b);
 int32_t pointless_cmp_string_8_16(uint8_t* a, uint16_t* b);
 int32_t pointless_cmp_string_8_32(uint8_t* a, uint32_t* b);

--- a/include/pointless/pointless_reader.h
+++ b/include/pointless/pointless_reader.h
@@ -25,13 +25,13 @@
 #include <pointless/pointless_validate.h>
 #include <pointless/pointless_reader_utils.h>
 
-int pointless_open_f(pointless_t* p, const char* fname, int force_ucs2, const char** error);
-int pointless_open_b(pointless_t* p, const void* buffer, size_t n_buffer, int force_ucs2, const char** error);
+int pointless_open_f(pointless_t* p, const char* fname, const char** error);
+int pointless_open_b(pointless_t* p, const void* buffer, size_t n_buffer, const char** error);
 
 // use these two with care. they don't perform any validation on the underlying data, which may cause
 // segfaults when accessed through the normal pointless-library functions
-int pointless_open_f_skip_validate(pointless_t* p, const char* fname, int force_ucs2, const char** error);
-int pointless_open_b_skip_validate(pointless_t* p, const void* buffer, size_t n_buffer, int force_ucs2, const char** error);
+int pointless_open_f_skip_validate(pointless_t* p, const char* fname, const char** error);
+int pointless_open_b_skip_validate(pointless_t* p, const void* buffer, size_t n_buffer, const char** error);
 
 void pointless_close(pointless_t* p);
 

--- a/include/pointless/pointless_reader_utils.h
+++ b/include/pointless/pointless_reader_utils.h
@@ -14,13 +14,6 @@ uint32_t* pointless_reader_unicode_value_ucs4(pointless_t* p, pointless_value_t*
 uint32_t pointless_reader_string_len(pointless_t* p, pointless_value_t* v);
 uint8_t* pointless_reader_string_value_ascii(pointless_t* p, pointless_value_t* v);
 
-#ifdef POINTLESS_WCHAR_T_IS_4_BYTES
-wchar_t* pointless_reader_unicode_value_wchar(pointless_t* p, pointless_value_t* v);
-#endif
-
-// note: caller must free() the returned buffers
-uint16_t* pointless_reader_unicode_value_ucs2_alloc(pointless_t* p, pointless_value_t* v, const char** error);
-
 // vectors
 uint32_t pointless_reader_vector_n_items(pointless_t* p, pointless_value_t* v);
 pointless_value_t* pointless_reader_vector_value(pointless_t* p, pointless_value_t* v);

--- a/include/pointless/pointless_unicode_utils.h
+++ b/include/pointless/pointless_unicode_utils.h
@@ -24,7 +24,6 @@ size_t pointless_ucs4_len(uint32_t* s);
 size_t pointless_ucs2_len(uint16_t* s);
 size_t pointless_ascii_len(uint8_t* s);
 size_t pointless_ucs1_len(uint8_t* s);
-size_t pointless_wchar_len(wchar_t* s);
 
 // strcpy()
 void pointless_ucs4_cpy(uint32_t* dst, const uint32_t* src);

--- a/include/pointless/pointless_validate.h
+++ b/include/pointless/pointless_validate.h
@@ -47,7 +47,6 @@ Checking all this is pretty expensive, and is done after the first set of tests.
 
 typedef struct {
 	pointless_t* p;
-	int force_ucs2;
 } pointless_validate_context_t;
 
 int32_t pointless_validate(pointless_validate_context_t* context, const char** error);

--- a/pointless_ext.h
+++ b/pointless_ext.h
@@ -261,7 +261,7 @@ static struct PyPointless_CAPI* PyPointless_IMPORT_CAPI(void)
 
 		if (context != (void*)POINTLESS_MAGIC_CONTEXT) {
 			Py_DECREF(c);
-			PyErr_Format(PyExc_ImportError, "invalid capsule context, was %x, expected %x", (int)context, (int)POINTLESS_MAGIC_CONTEXT);
+			PyErr_Format(PyExc_ImportError, "invalid capsule context, was %lx, expected %lx", (unsigned long*)context, (unsigned long*)POINTLESS_MAGIC_CONTEXT);
 			return 0;
 		}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ test-command = [
 ]
 
 # temporarily dropping pypy until we can figure out the string unit-test failure
-build = [ "cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*" ]
+build = [ "cp38-*", "cp39-*", "cp310-*", "cp311-*" , "cp312-*" ]
 # build = [ "pp*" ]
 archs = [ "auto64"]
 build-verbosity = 1
@@ -47,11 +47,11 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Database",
     "Topic :: Software Development :: Libraries"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.16"
+version = "1.0.17"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.7"

--- a/python/pointless_object.c
+++ b/python/pointless_object.c
@@ -172,12 +172,6 @@ static int PyPointless_init(PyPointless* self, PyObject* args, PyObject* kwds)
 
 	int do_validate = (validate == Py_True);
 
-#ifdef Py_UNICODE_WIDE
-	int force_ucs2 = 0;
-#else
-	int force_ucs2 = 1;
-#endif
-
 	if (PyUnicode_Check(fname_or_buffer)) {
 		string_of_unicode = PyUnicode_AsLatin1String(fname_or_buffer);
 
@@ -208,14 +202,14 @@ static int PyPointless_init(PyPointless* self, PyObject* args, PyObject* kwds)
 
 	if (do_validate) {
 		if (fname_)
-			i = pointless_open_f(&self->p, fname_, force_ucs2, &error);
+			i = pointless_open_f(&self->p, fname_, &error);
 		else
-			i = pointless_open_b(&self->p, buf, buflen, force_ucs2, &error);
+			i = pointless_open_b(&self->p, buf, buflen, &error);
 	} else {
 		if (fname_)
-			i = pointless_open_f_skip_validate(&self->p, fname_, force_ucs2, &error);
+			i = pointless_open_f_skip_validate(&self->p, fname_, &error);
 		else
-			i = pointless_open_b_skip_validate(&self->p, buf, buflen, force_ucs2, &error);
+			i = pointless_open_b_skip_validate(&self->p, buf, buflen, &error);
 	}
 
 	Py_END_ALLOW_THREADS

--- a/python/pointless_print.c
+++ b/python/pointless_print.c
@@ -161,10 +161,6 @@ static int _pypointless_value_repr(pointless_t* p, PyObject* u_value, _pypointle
 	int i = 0;
 
 	switch (PyUnicode_KIND(s_value)) {
-		case PyUnicode_WCHAR_KIND:
-			PyErr_SetString(PyExc_ValueError, "wchar unicode unsupported");
-			i = 0;
-			break;
 		case PyUnicode_1BYTE_KIND:
 			i = _pypointless_print_append_ucs1_(state, (uint8_t*)data, len);
 			break;
@@ -174,9 +170,9 @@ static int _pypointless_value_repr(pointless_t* p, PyObject* u_value, _pypointle
 		case PyUnicode_4BYTE_KIND:
 			i = _pypointless_print_append_ucs4_(state, (uint32_t*)data, len);
 			break;
+		// will happen for PyUnicode_WCHAR_KIND on python versions < 3.12
 		default:
-			assert(0);
-			PyErr_SetString(PyExc_ValueError, "strange unicode");
+			PyErr_SetString(PyExc_ValueError, "wchar unicode unsupported");
 			i = 0;
 			break;
 	}

--- a/python/pointless_pyobject_cmp.c
+++ b/python/pointless_pyobject_cmp.c
@@ -242,15 +242,23 @@ static _var_string_t pypointless_cmp_extract_string(pypointless_cmp_value_t* v, 
 	} else {
 		assert(PyUnicode_Check(v->value.py_object));
 
-		{
-
-#ifdef Py_UNICODE_WIDE
-			s.n_bits = 32;
-			s.string.string_32 = (uint32_t*)PyUnicode_AS_UNICODE(v->value.py_object);
-#else
-			s.n_bits = 16;
-			s.string.string_16 = (uint16_t*)PyUnicode_AS_UNICODE(v->value.py_object);
-#endif
+		switch (PyUnicode_KIND(v->value.py_object)) {
+			case PyUnicode_1BYTE_KIND:
+				s.n_bits = 8;
+				s.string.string_8 = (uint8_t*)PyUnicode_1BYTE_DATA(v->value.py_object);
+				break;
+			case PyUnicode_2BYTE_KIND:
+				s.n_bits = 16;
+				s.string.string_16 = (uint16_t*)PyUnicode_2BYTE_DATA(v->value.py_object);
+				break;
+			case PyUnicode_4BYTE_KIND:
+				s.n_bits = 32;
+				s.string.string_32 = (uint32_t*)PyUnicode_4BYTE_DATA(v->value.py_object);
+				break;
+			// will happen for PyUnicode_WCHAR_KIND on python versions < 3.12
+			default:
+				state->error = "hash statement fallthrough";
+				break;
 		}
 	}
 

--- a/python/pointless_pyobject_hash.c
+++ b/python/pointless_pyobject_hash.c
@@ -103,9 +103,6 @@ static uint32_t pyobject_hash_unicode_32(PyObject* py_object, pyobject_hash_stat
 		case POINTLESS_FF_VERSION_OFFSET_32_NEWHASH:
 		case POINTLESS_FF_VERSION_OFFSET_64_NEWHASH:
 			switch (PyUnicode_KIND(py_object)) {
-				case PyUnicode_WCHAR_KIND:
-					hash = pointless_hash_unicode_ucs4_v1_32((uint32_t*)PyUnicode_AS_UNICODE(py_object));
-					break;
 				case PyUnicode_1BYTE_KIND:
 					hash = pointless_hash_string_v1_32((uint8_t*)PyUnicode_1BYTE_DATA(py_object));
 					break;
@@ -115,6 +112,7 @@ static uint32_t pyobject_hash_unicode_32(PyObject* py_object, pyobject_hash_stat
 				case PyUnicode_4BYTE_KIND:
 					hash = pointless_hash_unicode_ucs4_v1_32((uint32_t*)PyUnicode_4BYTE_DATA(py_object));
 					break;
+				// will happen for PyUnicode_WCHAR_KIND on python versions < 3.12
 				default:
 					state->error = "hash statement fallthrough";
 					break;
@@ -124,9 +122,6 @@ static uint32_t pyobject_hash_unicode_32(PyObject* py_object, pyobject_hash_stat
 		case POINTLESS_FF_VERSION_OFFSET_32_NEWHASH:
 		case POINTLESS_FF_VERSION_OFFSET_64_NEWHASH:
 			switch (PyUnicode_KIND(py_object)) {
-				case PyUnicode_WCHAR_KIND:
-					hash = pointless_hash_unicode_ucs2_v1_32((uint16_t*)PyUnicode_AS_UNICODE(py_object));
-					break;
 				case PyUnicode_1BYTE_KIND:
 					hash = pointless_hash_string_v1_32((uint8_t*)PyUnicode_1BYTE_DATA(py_object));
 					break;
@@ -136,6 +131,7 @@ static uint32_t pyobject_hash_unicode_32(PyObject* py_object, pyobject_hash_stat
 				case PyUnicode_4BYTE_KIND:
 					hash = pointless_hash_unicode_ucs4_v1_32((uint32_t*)PyUnicode_4BYTE_DATA(py_object));
 					break;
+				// will happen for PyUnicode_WCHAR_KIND on python versions < 3.12
 				default:
 					state->error = "hash statement fallthrough";
 					break;

--- a/python/pointless_pyobject_hash.c
+++ b/python/pointless_pyobject_hash.c
@@ -99,7 +99,6 @@ static uint32_t pyobject_hash_unicode_32(PyObject* py_object, pyobject_hash_stat
 	uint32_t hash = 0;
 
 	switch (state->version) {
-		#ifdef Py_UNICODE_WIDE
 		case POINTLESS_FF_VERSION_OFFSET_32_NEWHASH:
 		case POINTLESS_FF_VERSION_OFFSET_64_NEWHASH:
 			switch (PyUnicode_KIND(py_object)) {
@@ -117,26 +116,6 @@ static uint32_t pyobject_hash_unicode_32(PyObject* py_object, pyobject_hash_stat
 					state->error = "hash statement fallthrough";
 					break;
 			}
-			break;
-		#else
-		case POINTLESS_FF_VERSION_OFFSET_32_NEWHASH:
-		case POINTLESS_FF_VERSION_OFFSET_64_NEWHASH:
-			switch (PyUnicode_KIND(py_object)) {
-				case PyUnicode_1BYTE_KIND:
-					hash = pointless_hash_string_v1_32((uint8_t*)PyUnicode_1BYTE_DATA(py_object));
-					break;
-				case PyUnicode_2BYTE_KIND:
-					hash = pointless_hash_unicode_ucs2_v1_32((uint16_t*)PyUnicode_2BYTE_DATA(py_object));
-					break;
-				case PyUnicode_4BYTE_KIND:
-					hash = pointless_hash_unicode_ucs4_v1_32((uint32_t*)PyUnicode_4BYTE_DATA(py_object));
-					break;
-				// will happen for PyUnicode_WCHAR_KIND on python versions < 3.12
-				default:
-					state->error = "hash statement fallthrough";
-					break;
-			}
-		#endif
 	}
 
 	return hash;

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def build_judy() -> None:
 
 	# adding last two flags because of compiler and/or code bugs
 	# see http://sourceforge.net/p/judy/mailman/message/32417284/
-	assert(sys.maxsize in (2**63 - 1, 2**31 - 1))
+	assert sys.maxsize in (2**63 - 1, 2**31 - 1)
 
 	if is_clang or is_gcc_46:
 		CFLAGS = '-DJU_64BIT -O0 -fPIC -fno-strict-aliasing -Wall -D_REENTRANT -D_GNU_SOURCE  -g'

--- a/src/pointless_cmp.c
+++ b/src/pointless_cmp.c
@@ -15,11 +15,6 @@ static int32_t pointless_cmp_create_rec_priv(pointless_create_t* c, pointless_co
 	if (n_ == (n_b))           return 1;       \
 	return SIMPLE_CMP(*(a), *(b));
 
-#ifdef POINTLESS_WCHAR_T_IS_4_BYTES
-int32_t pointless_cmp_wchar_wchar(wchar_t* a, wchar_t* b)
-	{ POINTLESS_CMP_STRING(a, b); }
-#endif
-
 int32_t pointless_cmp_string_8_8(uint8_t* a, uint8_t* b)
 	{ POINTLESS_CMP_STRING(a, b); }
 int32_t pointless_cmp_string_8_16(uint8_t* a, uint16_t* b)

--- a/src/pointless_reader.c
+++ b/src/pointless_reader.c
@@ -207,23 +207,6 @@ uint32_t* pointless_reader_unicode_value_ucs4(pointless_t* p, pointless_value_t*
 	return pointless_reader_unicode_value(p, v);
 }
 
-#ifdef POINTLESS_WCHAR_T_IS_4_BYTES
-wchar_t* pointless_reader_unicode_value_wchar(pointless_t* p, pointless_value_t* v)
-{
-	return (wchar_t*)pointless_reader_unicode_value_ucs4(p, v);
-}
-#endif
-
-uint16_t* pointless_reader_unicode_value_ucs2_alloc(pointless_t* p, pointless_value_t* v, const char** error)
-{
-	uint16_t* s = pointless_ucs4_to_ucs2(pointless_reader_unicode_value_ucs4(p, v));
-
-	if (s == 0)
-		*error = "out of memory";
-
-	return s;
-}
-
 uint32_t pointless_reader_string_len(pointless_t* p, pointless_value_t* v)
 {
 	assert(v->data.data_u32 < p->header->n_string_unicode);

--- a/src/pointless_reader.c
+++ b/src/pointless_reader.c
@@ -1,6 +1,6 @@
 #include <pointless/pointless_reader.h>
 
-static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int force_ucs2, int do_validate, const char** error)
+static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int do_validate, const char** error)
 {
 	// our header
 	if (buflen < sizeof(pointless_header_t)) {
@@ -53,7 +53,6 @@ static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int force_
 	// let us validate the damn thing
 	pointless_validate_context_t context;
 	context.p = p;
-	context.force_ucs2 = force_ucs2;
 
 	if (do_validate)
 		return pointless_validate(&context, error);
@@ -61,7 +60,7 @@ static int pointless_init(pointless_t* p, void* buf, uint64_t buflen, int force_
 		return 1;
 }
 
-static int _pointless_open_f(pointless_t* p, const char* fname, int force_ucs2, int do_validate, const char** error)
+static int _pointless_open_f(pointless_t* p, const char* fname, int do_validate, const char** error)
 {
 	p->fd = 0;
 	p->fd_len = 0;
@@ -120,7 +119,7 @@ static int _pointless_open_f(pointless_t* p, const char* fname, int force_ucs2, 
 		return 0;
 	}
 
-	if (!pointless_init(p, p->fd_ptr, p->fd_len, force_ucs2, do_validate, error)) {
+	if (!pointless_init(p, p->fd_ptr, p->fd_len, do_validate, error)) {
 		pointless_close(p);
 		return 0;
 	}
@@ -128,14 +127,14 @@ static int _pointless_open_f(pointless_t* p, const char* fname, int force_ucs2, 
 	return 1;
 }
 
-int pointless_open_f(pointless_t* p, const char* fname, int force_ucs2, const char** error)
+int pointless_open_f(pointless_t* p, const char* fname, const char** error)
 {
-	return _pointless_open_f(p, fname, force_ucs2, 1, error);
+	return _pointless_open_f(p, fname, 1, error);
 }
 
-int pointless_open_f_skip_validate(pointless_t* p, const char* fname, int force_ucs2, const char** error)
+int pointless_open_f_skip_validate(pointless_t* p, const char* fname, const char** error)
 {
-	return _pointless_open_f(p, fname, force_ucs2, 0, error);
+	return _pointless_open_f(p, fname, 0, error);
 }
 
 void pointless_close(pointless_t* p)
@@ -149,7 +148,7 @@ void pointless_close(pointless_t* p)
 	pointless_free(p->buf);
 }
 
-static int _pointless_open_b(pointless_t* p, const void* buffer, size_t n_buffer, int force_ucs2, int do_validate, const char** error)
+static int _pointless_open_b(pointless_t* p, const void* buffer, size_t n_buffer, int do_validate, const char** error)
 {
 	p->fd = 0;
 	p->fd_len = 0;
@@ -165,7 +164,7 @@ static int _pointless_open_b(pointless_t* p, const void* buffer, size_t n_buffer
 
 	memcpy(p->buf, buffer, n_buffer);
 
-	if (!pointless_init(p, p->buf, p->buflen, force_ucs2, do_validate, error)) {
+	if (!pointless_init(p, p->buf, p->buflen, do_validate, error)) {
 		pointless_close(p);
 		return 0;
 	}
@@ -173,14 +172,14 @@ static int _pointless_open_b(pointless_t* p, const void* buffer, size_t n_buffer
 	return 1;
 }
 
-int pointless_open_b(pointless_t* p, const void* buffer, size_t n_buffer, int force_ucs2, const char** error)
+int pointless_open_b(pointless_t* p, const void* buffer, size_t n_buffer, const char** error)
 {
-	return _pointless_open_b(p, buffer, n_buffer, force_ucs2, 1, error);
+	return _pointless_open_b(p, buffer, n_buffer, 1, error);
 }
 
-int pointless_open_b_skip_validate(pointless_t* p, const void* buffer, size_t n_buffer, int force_ucs2, const char** error)
+int pointless_open_b_skip_validate(pointless_t* p, const void* buffer, size_t n_buffer, const char** error)
 {
-	return _pointless_open_b(p, buffer, n_buffer, force_ucs2, 0, error);
+	return _pointless_open_b(p, buffer, n_buffer, 0, error);
 }
 
 pointless_value_t* pointless_root(pointless_t* p)

--- a/src/pointless_recreate.c
+++ b/src/pointless_recreate.c
@@ -334,7 +334,7 @@ int pointless_recreate_64(const char* fname_in, const char* fname_out, const cha
 	// open source
 	pointless_t p;
 
-	if (!pointless_open_f(&p, fname_in, 0, error))
+	if (!pointless_open_f(&p, fname_in, error))
 		return 0;
 
 	// create destination

--- a/src/pointless_unicode_utils.c
+++ b/src/pointless_unicode_utils.c
@@ -17,8 +17,6 @@ size_t pointless_ascii_len(uint8_t* s)
 	{ POINTLESS_STRING_LEN(s); }
 size_t pointless_ucs1_len(uint8_t* s)
 	{ POINTLESS_STRING_LEN(s); }
-size_t pointless_wchar_len(wchar_t* s)
-	{ POINTLESS_STRING_LEN(s); }
 
 void pointless_ucs4_cpy(uint32_t* dst, const uint32_t* src)
 	{ POINTLESS_STRING_CPY(dst, src); }

--- a/src/pointless_unicode_utils.c
+++ b/src/pointless_unicode_utils.c
@@ -6,8 +6,6 @@
 
 int pointless_is_ucs4_ascii(uint32_t* s)
 	{ POINTLESS_BELOW_RANGE(s, UINT8_MAX); }
-int pointless_is_ucs4_ucs2(uint32_t* s)
-	{ POINTLESS_BELOW_RANGE(s, UINT16_MAX); }
 int pointless_is_ucs2_ascii(uint16_t* s)
 	{ POINTLESS_BELOW_RANGE(s, UINT8_MAX); }
 
@@ -33,23 +31,6 @@ void pointless_ascii_cpy(uint8_t* dst, const uint8_t* src)
 #undef POINTLESS_STRING_LEN
 #undef POINTLESS_STRING_CPY
 
-uint16_t* pointless_ucs4_to_ucs2(uint32_t* ucs4)
-{
-	assert(pointless_is_ucs4_ucs2(ucs4));
-	size_t n = pointless_ucs4_len(ucs4);
-	uint16_t* ucs2_ = (uint16_t*)pointless_malloc(sizeof(uint16_t) * (n + 1));
-
-	if (ucs2_ == 0)
-		return 0;
-
-	uint16_t* ucs2 = ucs2_;
-
-	while (*ucs4)
-		*ucs2++ = (uint16_t)*ucs4++;
-
-	*ucs2 = 0;
-	return ucs2_;
-}
 
 uint8_t* pointless_ucs4_to_ascii(uint32_t* ucs4)
 {

--- a/src/pointless_validate_heap.c
+++ b/src/pointless_validate_heap.c
@@ -125,11 +125,6 @@ static int32_t pointless_validate_unicode_heap(pointless_validate_context_t* con
 		return 0;
 	}
 
-	if (context->force_ucs2 && !pointless_is_ucs4_ucs2(s)) {
-		*error = "there are strings which don't fit in 16-bits";
-		return 0;
-	}
-
 	return 1;
 }
 

--- a/tests/c_api/create.c
+++ b/tests/c_api/create.c
@@ -25,7 +25,7 @@ void query_wrapper(const char* fname, query_cb cb)
 	pointless_t p;
 	const char* error;
 
-	if (!pointless_open_f(&p, fname, 0, &error)) {
+	if (!pointless_open_f(&p, fname, &error)) {
 		fprintf(stderr, "pointless_open_f() failure: %s\n", error);
 		exit(EXIT_FAILURE);
 	}

--- a/tests/c_api/main.c
+++ b/tests/c_api/main.c
@@ -5,7 +5,7 @@ static void print_map(const char* fname)
 	pointless_t p;
 	const char* error = 0;
 
-	if (!pointless_open_f(&p, fname, 0, &error)) {
+	if (!pointless_open_f(&p, fname, &error)) {
 		fprintf(stderr, "pointless_open_f() failure: %s\n", error);
 		exit(EXIT_FAILURE);
 	}
@@ -25,7 +25,7 @@ static void measure_load_time(const char* fname)
 
 	clock_t t_0 = clock();
 
-	if (!pointless_open_f(&p, fname, 0, &error)) {
+	if (!pointless_open_f(&p, fname, &error)) {
 		fprintf(stderr, "pointless_open_f() failure: %s\n", error);
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
This PR adds support for Python 3.12, and drops support for Python 3.7. One breaking change is that UCS2 builds of Python are no longer supported.