### PR TITLE
Feature/fix warnings emitted by gcc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,9 @@ def build_judy() -> None:
 	assert sys.maxsize in (2**63 - 1, 2**31 - 1)
 
 	if is_clang or is_gcc_46:
-		CFLAGS = '-DJU_64BIT -O0 -fPIC -fno-strict-aliasing -Wall -D_REENTRANT -D_GNU_SOURCE  -g'
+		CFLAGS = '-DJU_64BIT -O0 -fPIC -fno-strict-aliasing -Wextra -Werror  -D_REENTRANT -D_GNU_SOURCE  -g'
 	else:
-		CFLAGS = '-DJU_64BIT -O0 -fPIC -fno-strict-aliasing -fno-aggressive-loop-optimizations'
+		CFLAGS = '-DJU_64BIT -O0 -fPIC -fno-strict-aliasing -Wextra -Werror  -D_REENTRANT -D_GNU_SOURCE  -g -fno-aggressive-loop-optimizations'
 
 	exitcode, output = subprocess.getstatusoutput('(cd judy-1.0.5/src; CC=\'%s\' COPT=\'%s\' sh ./sh_build)' % (CC, CFLAGS))
 
@@ -102,8 +102,14 @@ setup(
 			extra_compile_args=[
 				'-I./include',
 				'-I./judy-1.0.5/src',
-				'-Wall',
+				'-Wextra',
+				'-Werror',
 				'-Wno-strict-prototypes',
+				'-Wno-unused-parameter',
+				'-Wno-missing-field-initializers',
+				'-Wno-unused-function',
+				'-Wno-cast-function-type',
+				'-Wno-incompatible-pointer-types',
 				'-g',
 				'-D_GNU_SOURCE',
 				'-O2',

--- a/src/pointless_cycle_marker_wrappers.c
+++ b/src/pointless_cycle_marker_wrappers.c
@@ -74,7 +74,7 @@ static uint64_t _reader_pointless_child_at(void* user_, uint64_t v_, uint32_t i)
 			children = pointless_reader_vector_value(user->p, v);
 			return (uint64_t)(children + i);
 		case POINTLESS_SET_VALUE:
-			assert(0 <= i && i <= 1);
+			assert(i <= 1);
 
 			if (i == 0)
 				return (uint64_t)pointless_set_hash_vector(user->p, v);
@@ -83,7 +83,7 @@ static uint64_t _reader_pointless_child_at(void* user_, uint64_t v_, uint32_t i)
 
 			break;
 		case POINTLESS_MAP_VALUE_VALUE:
-			assert(0 <= i && i <= 2);
+			assert(i <= 2);
 
 			if (i == 0)
 				return (uint64_t)pointless_map_hash_vector(user->p, v);

--- a/src/pointless_eval.c
+++ b/src/pointless_eval.c
@@ -62,10 +62,12 @@ static const char* pointless_eval_get_single(pointless_t* p, pointless_value_t* 
 		// integer
 		case '-':
 			is_neg = 1;
+			break;
 		case '+':
 			e += 1;
 			if (!('0' <= *e && *e  <= '9'))
 				return 0;
+			break;
 		case '0':
 		case '1':
 		case '2':

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,1 @@
-Twisted==22.10.0
+Twisted==24.3.0

--- a/tests/compile.sh
+++ b/tests/compile.sh
@@ -5,7 +5,7 @@ INCLUDE="-I../include -I../judy-1.0.5/src/"
 #FLAGS="-pedantic -Wall -std=c99 -D_REENTRANT -D_GNU_SOURCE    -O2 -g -pg -fno-omit-frame-pointer -fno-inline-functions -fno-inline-functions-called-once -fno-optimize-sibling-calls"
 #FLAGS="-pg -g -fno-omit-frame-pointer -O2 -fno-inline-functions -fno-inline-functions-called-once -fno-optimize-sibling-calls -fno-inline"
 
-FLAGS="-Wall -D_REENTRANT -D_GNU_SOURCE"
+FLAGS="-Wextra -Werror -D_REENTRANT -D_GNU_SOURCE"
 SOURCE="../src/*.c ./c_api/*.c  ../judy-1.0.5/src/libJudy.a"
 
 LDFLAGS="-lpthread -ldl"


### PR DESCRIPTION
The GCC flags '-Wextra` on combination with `-Werror` gave us 4 errors.

Two of them indicated proper bugs (but minor ones) in `pointless_eval_get_single`. The two other were basically tautologies.

