### PR TITLE
don't increment vector iterator if object instantation failed

### DIFF
--- a/python/pointless_bitvector.c
+++ b/python/pointless_bitvector.c
@@ -848,6 +848,10 @@ static PyObject* PyPointlessBitvectorIter_iternext(PyPointlessBitvectorIter* ite
 
 	if (iter->iter_state < n_bits) {
 		PyObject* bit = PyPointlessBitvector_subscript_priv(iter->bitvector, iter->iter_state);
+
+		if (bit == 0)
+			return 0;
+
 		iter->iter_state += 1;
 		return bit;
 	}

--- a/python/pointless_prim_vector.c
+++ b/python/pointless_prim_vector.c
@@ -673,6 +673,8 @@ static PyObject* PyPointlessPrimVectorIter_iternext(PyPointlessPrimVectorIter* i
 
 	if (iter->iter_state < n_items) {
 		PyObject* item = PyPointlessPrimVector_subscript_priv(iter->vector, iter->iter_state);
+		if (item == 0)
+			return 0;
 		iter->iter_state += 1;
 		return item;
 	}
@@ -695,6 +697,8 @@ static PyObject* PyPointlessPrimVectorRevIter_iternext(PyPointlessPrimVectorRevI
 
 	if (iter->iter_state < n_items) {
 		PyObject* item = PyPointlessPrimVector_subscript_priv(iter->vector, n_items - iter->iter_state - 1);
+		if (item == 0)
+			return 0;
 		iter->iter_state += 1;
 		return item;
 	}

--- a/python/pointless_vector.c
+++ b/python/pointless_vector.c
@@ -260,6 +260,10 @@ static PyObject* PyPointlessVectorIter_iternext(PyPointlessVectorIter* iter)
 
 	if (iter->iter_state < n_items) {
 		PyObject* item = PyPointlessVector_subscript_priv(iter->vector, iter->iter_state);
+
+		if (item == 0)
+			return 0;
+
 		iter->iter_state += 1;
 		return item;
 	}
@@ -281,6 +285,10 @@ static PyObject* PyPointlessVectorRevIter_iternext(PyPointlessVectorIter* iter)
 
 	if (iter->iter_state < n_items) {
 		PyObject* item = PyPointlessVector_subscript_priv(iter->vector, n_items - iter->iter_state - 1);
+
+		if (item == 0)
+			return 0;
+
 		iter->iter_state += 1;
 		return item;
 	}

--- a/python/pointless_vector.c
+++ b/python/pointless_vector.c
@@ -718,7 +718,6 @@ static PyMemberDef PyPointlessVector_memberlist[] = {
 static PyMethodDef PyPointlessVector_methods[] = {
 	{"max",          (PyCFunction)PyPointlessVector_max,          METH_NOARGS,  ""},
 	{"min",          (PyCFunction)PyPointlessVector_min,          METH_NOARGS,  ""},
-	{"range",        (PyCFunction)PyPointlessVector_range,          METH_NOARGS,  ""},
 	{"bisect_left",  (PyCFunction)PyPointlessVector_bisect_left,  METH_VARARGS, ""},
 	{"__reversed__", (PyCFunction)PyPointlessVector_rev_iter,     METH_NOARGS,  ""},
 	{"__sizeof__",   (PyCFunction)PyPointlessVector_sizeof,       METH_NOARGS,  ""},

--- a/python/pointless_vector.c
+++ b/python/pointless_vector.c
@@ -718,6 +718,7 @@ static PyMemberDef PyPointlessVector_memberlist[] = {
 static PyMethodDef PyPointlessVector_methods[] = {
 	{"max",          (PyCFunction)PyPointlessVector_max,          METH_NOARGS,  ""},
 	{"min",          (PyCFunction)PyPointlessVector_min,          METH_NOARGS,  ""},
+	{"range",        (PyCFunction)PyPointlessVector_range,          METH_NOARGS,  ""},
 	{"bisect_left",  (PyCFunction)PyPointlessVector_bisect_left,  METH_VARARGS, ""},
 	{"__reversed__", (PyCFunction)PyPointlessVector_rev_iter,     METH_NOARGS,  ""},
 	{"__sizeof__",   (PyCFunction)PyPointlessVector_sizeof,       METH_NOARGS,  ""},


### PR DESCRIPTION
There is an edge case where if we failed to create a `PyObject` for a vector item during iteration we still increment the cursor.