### PR TITLE
Build sdist package only once in github actions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,6 +34,7 @@ jobs:
         run: cibuildwheel --config-file pyproject.toml --output-dir wheelhouse
 
       - name: Build sdist
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./build-sdist.sh
 
       - name: List wheels


### PR DESCRIPTION
No need to generate the same sdist package for all architectures since
we can push only once on pypi
