### PR TITLE
Enable wheel generation for macos_arm64

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, ubuntu-latest]
+        os: [macos-13, macos-14, ubuntu-latest]
         python-version: ['3.11']
 
     steps:


### PR DESCRIPTION
`macos-14` is using the arm64 architecture
`macos-13` is the last version using the x86_64 architecture
