### PR TITLE
Don't test wheels when building in Qemu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ environment = "CC=gcc"
 
 # since we run the aarch64 builds in QEMU, they are slow, so
 # we skip tests on all versions but 3.12
-skip = [
+test-skip = [
     "cp39-manylinux_aarch64",
     "cp39-musllinux_aarch64",
     "cp310-manylinux_aarch64",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,19 @@ find = {namespaces = false, exclude = [ "pointless.tests" ]}
 archs = ["auto64", "aarch64"]
 environment = "CC=gcc"
 
+# since we run the aarch64 builds in QEMU, they are slow, so
+# we skip tests on all versions but 3.12
+skip = [
+    "cp39-manylinux_aarch64",
+    "cp39-musllinux_aarch64",
+    "cp310-manylinux_aarch64",
+    "cp310-musllinux_aarch64",
+    "cp311-manylinux_aarch64",
+    "cp311-musllinux_aarch64",
+    "cp313-manylinux_aarch64",
+    "cp313-musllinux_aarch64",
+]
+
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "universal2", "arm64"]
 environment = "CC=clang"


### PR DESCRIPTION
Since we build `aarch64` in Qemu the builds are very slow. This PR disables tests for those.