### PR TITLE
remove PointlessPrimVector.fast_remove()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.25"
+version = "1.0.26"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ test-command = [
     "{package}/build_judy.sh",
     "(cd {package}/tests && ./compile.sh)",
     "(cd {package}/tests && ./a.out --unit-test)",
-    "(cd {package} && PYTHONPATH=$(pwd) python -m twisted.trial tests.python_api)",
+    "# (cd {package} && PYTHONPATH=$(pwd) python -m twisted.trial tests.python_api)",
 ]
 
 # temporarily dropping pypy until we can figure out the string unit-test failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ test-command = [
     "{package}/build_judy.sh",
     "(cd {package}/tests && ./compile.sh)",
     "(cd {package}/tests && ./a.out --unit-test)",
-    "# (cd {package} && PYTHONPATH=$(pwd) python -m twisted.trial tests.python_api)",
+    "(cd {package} && PYTHONPATH=$(pwd) python -m twisted.trial tests.python_api)",
 ]
 
 # temporarily dropping pypy until we can figure out the string unit-test failure

--- a/python/pointless_prim_vector.c
+++ b/python/pointless_prim_vector.c
@@ -1123,24 +1123,6 @@ static PyObject* PyPointlessPrimVector_remove(PyPointlessPrimVector* self, PyObj
 	return Py_None;
 }
 
-static PyObject* PyPointlessPrimVector_fast_remove(PyPointlessPrimVector* self, PyObject* args)
-{
-	if (!PyPointlessPrimVector_can_resize(self))
-		return 0;
-
-	size_t i = PyPointlessPrimVector_index_(self, args, "fast_remove");
-
-	if (i == (SIZE_MAX-1))
-		return 0;
-
-	// swap with last item and remove last item
-	pointless_dynarray_swap(&self->array, i, pointless_dynarray_n_items(&self->array) - 1);
-	pointless_dynarray_pop(&self->array);
-
-	Py_INCREF(Py_None);
-	return Py_None;
-}
-
 static size_t PyPointlessPrimVector_type_size(PyPointlessPrimVector* self)
 {
 	size_t typesize = 0, i;

--- a/python/pointless_prim_vector.c
+++ b/python/pointless_prim_vector.c
@@ -1954,7 +1954,6 @@ static PyMethodDef PyPointlessPrimVector_methods[] = {
 	{"pop_bulk",          (PyCFunction)PyPointlessPrimVector_pop_bulk,      METH_VARARGS, ""},
 	{"index",             (PyCFunction)PyPointlessPrimVector_index,         METH_VARARGS,  ""},
 	{"remove",            (PyCFunction)PyPointlessPrimVector_remove,        METH_VARARGS,  ""},
-	{"fast_remove",       (PyCFunction)PyPointlessPrimVector_fast_remove,   METH_VARARGS,  ""},
 	{"serialize",         (PyCFunction)PyPointlessPrimVector_serialize,     METH_NOARGS,  ""},
 	{"sort",              (PyCFunction)PyPointlessPrimVector_sort,          METH_NOARGS,  ""},
 	{"sort_proj",         (PyCFunction)PyPointlessPrimVector_sort_proj,     METH_VARARGS, ""},

--- a/tests/python_api/test_primvector.py
+++ b/tests/python_api/test_primvector.py
@@ -94,33 +94,6 @@ class TestPrimVector(unittest.TestCase):
 							self.assertRaises(ValueError, w.remove, V)
 							self.assertRaises(ValueError, v.remove, V)
 
-	def testFastRemove(self):
-		for tc in ['i8', 'u8', 'i16', 'u16', 'i32', 'u32', 'f']:
-			for i in range(1, 100):
-				v = RandomPrimVector(i - 1, tc)
-
-				# make sure one element is an integer, to test int-float comparison
-				if tc == 'f':
-					v.append(1.0)
-				else:
-					v.append(1)
-
-				w = list(v)
-
-				for _ in range(100):
-					if len(w) > 0:
-						V = random.choice(v)
-
-						w.remove(V)
-						v.fast_remove(V)
-						self.assertListEqual(sorted(w), sorted(v))
-
-						V = random.randint(0, 1000)
-
-						if V not in v:
-							self.assertRaises(ValueError, w.remove, V)
-							self.assertRaises(ValueError, v.fast_remove, V)
-
 	def testPop(self):
 		w = pointless.PointlessPrimVector('u32')
 		self.assertRaises(IndexError, w.pop)


### PR DESCRIPTION
It wasn't particularly useful, and easily performed using current primitives 