### PR TITLE
skip unnecessary `PyIndex_Check`s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.29"
+version = "1.0.30"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.10"

--- a/python/pointless_bitvector.c
+++ b/python/pointless_bitvector.c
@@ -216,13 +216,7 @@ static Py_ssize_t PyPointlessBitvector_length(PyPointlessBitvector* self)
 
 static int PyPointlessBitvector_check_index(PyPointlessBitvector* self, PyObject* item, Py_ssize_t* i)
 {
-	// if this is not an index: throw an exception
-	if (!PyIndex_Check(item)) {
-		PyErr_Format(PyExc_TypeError, "BitVector: integer indexes please, got <%s>\n", item->ob_type->tp_name);
-		return 0;
-	}
-
-	// if index value is not an integer: throw an exception
+	// if index value is not an integer or too large of an integer: throw an exception
 	*i = PyNumber_AsSsize_t(item, PyExc_IndexError);
 
 	if (*i == -1 && PyErr_Occurred())

--- a/python/pointless_prim_vector.c
+++ b/python/pointless_prim_vector.c
@@ -490,12 +490,6 @@ static Py_ssize_t PyPointlessPrimVector_length(PyPointlessPrimVector* self)
 
 static int PyPointlessPrimVector_check_index(PyPointlessPrimVector* self, PyObject* item, Py_ssize_t* i)
 {
-	// if this is not an index: throw an exception
-	if (!PyIndex_Check(item)) {
-		PyErr_Format(PyExc_TypeError, "PrimVector: integer indexes please, got <%s>\n", item->ob_type->tp_name);
-		return 0;
-	}
-
 	// if index value is not an integer: throw an exception
 	*i = PyNumber_AsSsize_t(item, PyExc_IndexError);
 
@@ -606,20 +600,15 @@ static int PyPointlessPrimVector_ass_item(PyPointlessPrimVector* self, Py_ssize_
 
 static int PyPointlessPrimVector_ass_subscript(PyPointlessPrimVector* self, PyObject* item, PyObject* value)
 {
-	if (PyIndex_Check(item)) {
-		Py_ssize_t i = PyNumber_AsSsize_t(item, PyExc_IndexError);
+	Py_ssize_t i = PyNumber_AsSsize_t(item, PyExc_IndexError);
 
-		if (i == -1 && PyErr_Occurred())
-			return -1;
-
-		if (i < 0)
-			i += PyList_GET_SIZE(self);
-
-		return PyPointlessPrimVector_ass_item(self, i, value);
-	} else {
-		PyErr_Format(PyExc_TypeError, "indices must be integers %.200s", item->ob_type->tp_name);
+	if (i == -1 && PyErr_Occurred())
 		return -1;
-	}
+
+	if (i < 0)
+		i += PyList_GET_SIZE(self);
+
+	return PyPointlessPrimVector_ass_item(self, i, value);
 }
 
 

--- a/python/pointless_vector.c
+++ b/python/pointless_vector.c
@@ -72,12 +72,6 @@ static Py_ssize_t PyPointlessVector_length(PyPointlessVector* self)
 
 static int PyPointlessVector_check_index(PyPointlessVector* self, PyObject* item, Py_ssize_t* i)
 {
-	// if this is not an index: throw an exception
-	if (!PyIndex_Check(item)) {
-		PyErr_Format(PyExc_TypeError, "PointlessVector: integer indexes please, got <%s>\n", item->ob_type->tp_name);
-		return 0;
-	}
-
 	// if index value is not an integer: throw an exception
 	*i = PyNumber_AsSsize_t(item, PyExc_IndexError);
 


### PR DESCRIPTION
We can skip it since these calls are followed by `PyNumber_AsSsize_t`, which does the same thing anyways.

The only thing that changes is the exception raised.