### PR TITLE
add method to bitvector to extract bits set

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v3.3
+    - uses: pypa/cibuildwheel@v3.4
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.29"
+version = "1.0.30"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.10"

--- a/python/pointless_bitvector.c
+++ b/python/pointless_bitvector.c
@@ -708,14 +708,14 @@ static PyPointlessPrimVector* PyPointlessBitvector_bits_to_vector(PyPointlessBit
 	PyPointlessPrimVector* vector = 0;
 
 	pointless_dynarray_t array;
-	pointless_dynarray_init(array, sizeof(uint32_t));
+	pointless_dynarray_init(&array, sizeof(uint32_t));
 
 	if (self->is_pointless)
 		n_bits = pointless_reader_bitvector_n_bits(&self->pp->p, &self->v);
 	else
 		n_bits = self->primitive_n_bits;
 
-	for (i = 0; i < n_bits) {
+	for (i = 0; i < n_bits; i++) {
 		if (self->is_pointless)
 			is_set = pointless_reader_bitvector_is_set(&self->pp->p, &self->v, i);
 		else
@@ -735,7 +735,6 @@ cleanup:
 	pointless_dynarray_destroy(&array);
 	return vector;
 }
-
 
 
 static PyObject* PyPointlessBitvector_copy(PyPointlessBitvector* self)

--- a/python/pointless_bitvector.c
+++ b/python/pointless_bitvector.c
@@ -648,7 +648,7 @@ static PyObject* PyPointlessBitvector_append_bulk(PyPointlessBitvector* self, Py
 	if (!PyPointlessBitvector_extend_by(self, PyPointlessBitvector_length(other), 0))
 		return 0;
 
-	for (size_t i = 0; i < PyPointlessBitvector_length(other); i++) {
+	for (size_t i = 0; i < (uint32_t)PyPointlessBitvector_length(other); i++) {
 		if (PyPointlessBitvector_is_set(other, i))
 			bm_set_(self->primitive_bits, n_before + i);
 	}
@@ -723,17 +723,15 @@ static PyPointlessPrimVector* PyPointlessBitvector_bits_to_vector(PyPointlessBit
 
 
 		if (is_set) {
-			if (!pointless_dynarray_push(&array, &i))
-				goto cleanup;
+			if (!pointless_dynarray_push(&array, &i)) {
+				pointless_dynarray_destroy(&array);
+				PyErr_NoMemory();
+				return 0;
+			}
 		}
 	}
 
-	vector = PyPointlessPrimVector_from_T_vector(&array, sizeof(uint32_t));
-
-cleanup:
-
-	pointless_dynarray_destroy(&array);
-	return vector;
+	return PyPointlessPrimVector_from_T_vector(&array, sizeof(uint32_t));
 }
 
 

--- a/python/pointless_bitvector.c
+++ b/python/pointless_bitvector.c
@@ -701,6 +701,43 @@ static PyObject* PyPointlessBitvector_pop(PyPointlessBitvector* self)
 	}
 }
 
+
+static PyPointlessPrimVector* PyPointlessBitvector_bits_to_vector(PyPointlessBitvector* self)
+{
+	uint32_t n_bits = 0, i, is_set;
+	PyPointlessPrimVector* vector = 0;
+
+	pointless_dynarray_t array;
+	pointless_dynarray_init(array, sizeof(uint32_t));
+
+	if (self->is_pointless)
+		n_bits = pointless_reader_bitvector_n_bits(&self->pp->p, &self->v);
+	else
+		n_bits = self->primitive_n_bits;
+
+	for (i = 0; i < n_bits) {
+		if (self->is_pointless)
+			is_set = pointless_reader_bitvector_is_set(&self->pp->p, &self->v, i);
+		else
+			is_set = (bm_is_set_(self->primitive_bits, i) != 0);
+
+
+		if (is_set) {
+			if (!pointless_dynarray_push(&array, &i))
+				goto cleanup;
+		}
+	}
+
+	vector = PyPointlessPrimVector_from_T_vector(&array, sizeof(uint32_t));
+
+cleanup:
+
+	pointless_dynarray_destroy(&array);
+	return vector;
+}
+
+
+
 static PyObject* PyPointlessBitvector_copy(PyPointlessBitvector* self)
 {
 	void* bits = 0;
@@ -778,7 +815,8 @@ static PyMethodDef PyPointlessBitvector_methods[] = {
 	{"extend_true",   (PyCFunction)PyPointlessBitvector_extend_true,    METH_VARARGS, ""},
 	{"pop",           (PyCFunction)PyPointlessBitvector_pop,            METH_NOARGS,  ""},
 	{"copy",          (PyCFunction)PyPointlessBitvector_copy,           METH_NOARGS,  ""},
-	{"__sizeof__",    (PyCFunction)PyPointlessBitvector_sizeof,         METH_NOARGS,   ""},
+	{"bits_to_vector",(PyCFunction)PyPointlessBitvector_bits_to_vector, METH_NOARGS,  ""},
+	{"__sizeof__",    (PyCFunction)PyPointlessBitvector_sizeof,         METH_NOARGS,  ""},
 	{NULL, NULL}
 };
 


### PR DESCRIPTION
The method `PointlessBitvector.bits_to_vector()` will return a pointless primvector of u32's with a value for each index where a bit is set in the bit vector.