### PR TITLE
numpy serialization support

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-26]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5

--- a/pointless_ext.c
+++ b/pointless_ext.c
@@ -89,9 +89,9 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_pointless(void)
 {
-	// import_array() (which tries to import the numpy packages) does
-	// its own "return null", so we try it first
-	import_array();
+    if (PyArray_ImportNumPyAPI() < 0) {
+        return NULL;
+    }
 
 	if (sizeof(Word_t) != sizeof(void*)) {
 		PyErr_SetString(PyExc_ValueError, "word size mismatch");

--- a/pointless_ext.c
+++ b/pointless_ext.c
@@ -87,22 +87,24 @@ static struct PyModuleDef moduledef = {
 	NULL
 };
 
-#define MODULEINITERROR return NULL
-PyMODINIT_FUNC
-
-PyInit_pointless(void)
+PyMODINIT_FUNC PyInit_pointless(void)
 {
+	// import_array() (which tries to import the numpy packages) does
+	// its own "return null", so we try it first
+	import_array();
+
 	if (sizeof(Word_t) != sizeof(void*)) {
 		PyErr_SetString(PyExc_ValueError, "word size mismatch");
-		MODULEINITERROR;
+		return NULL;
 	}
+
 
 	PyObject* module_pointless = 0;
 
 	module_pointless = PyModule_Create(&moduledef);
 
 	if (module_pointless == 0) {
-		MODULEINITERROR;
+		return NULL;
 	}
 
 	struct {
@@ -131,14 +133,14 @@ PyInit_pointless(void)
 	for (i = 0; i < 15; i++) {
 		if (PyType_Ready(types[i].type) < 0) {
 			Py_DECREF(module_pointless);
-			MODULEINITERROR;
+			return NULL;
 		}
 
 		Py_INCREF((PyObject*)types[i].type);
 
 		if (PyModule_AddObject(module_pointless, types[i].name, (PyObject*)types[i].type) != 0) {
 			Py_DECREF(module_pointless);
-			MODULEINITERROR;
+			return NULL;
 		}
 	}
 
@@ -146,20 +148,18 @@ PyInit_pointless(void)
 
 	if (c_api == 0) {
 		Py_DECREF(module_pointless);
-		MODULEINITERROR;
+		return NULL;
 	}
 
 	if (PyCapsule_SetContext(c_api, (void*)POINTLESS_MAGIC_CONTEXT) != 0) {
 		Py_DECREF(module_pointless);
-		MODULEINITERROR;
+		return NULL;
 	}
 
 	if (PyModule_AddObject(module_pointless, "pointless_CAPI", c_api) != 0) {
 		Py_DECREF(module_pointless);
-		MODULEINITERROR;
+		return NULL;
 	}
 
     return module_pointless;
 }
-
-#undef MODULEINITERROR

--- a/pointless_ext.h
+++ b/pointless_ext.h
@@ -2,6 +2,7 @@
 #define __POINTLESS__MODULE__H__
 
 #include <Python.h>
+#include <numpy/arrayobject.h>
 
 #include "structmember.h"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ before-test = [
 find = {namespaces = false, exclude = [ "pointless.tests" ]}
 
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm", "numpy>=2.4.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ test-command = [
 ]
 
 # temporarily dropping pypy until we can figure out the string unit-test failure
-build = [ "cp310-*", "cp311-*" , "cp312-*" , "cp313-*", "cp314-*"]
+build = [ "cp311-*" , "cp312-*" , "cp313-*", "cp314-*"]
 build-verbosity = 1
 
 [tool.cibuildwheel.linux]
@@ -40,7 +40,7 @@ name = "pointless"
 version = "1.0.33"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Other Environment",
@@ -50,8 +50,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.cibuildwheel]
 archs = "auto64"
-test-requires = "Twisted==25.5.0"
+test-requires = "Twisted==26.4.0"
 test-command = [
     "python {package}/sanity-check.py",
     "(cd {package} && PYTHONPATH=$(pwd) python -m twisted.trial tests.python_api)",
@@ -37,7 +37,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.32"
+version = "1.0.33"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.10"
@@ -58,6 +58,10 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Topic :: Database",
     "Topic :: Software Development :: Libraries"
+]
+dependencies=[
+    # first version supporting Python 3.14
+    "numpy>=2.4.0"
 ]
 
 [project.urls]

--- a/python/pointless_bitvector.c
+++ b/python/pointless_bitvector.c
@@ -699,7 +699,6 @@ static PyObject* PyPointlessBitvector_pop(PyPointlessBitvector* self)
 static PyPointlessPrimVector* PyPointlessBitvector_bits_to_vector(PyPointlessBitvector* self)
 {
 	uint32_t n_bits = 0, i, is_set;
-	PyPointlessPrimVector* vector = 0;
 
 	pointless_dynarray_t array;
 	pointless_dynarray_init(&array, sizeof(uint32_t));

--- a/python/pointless_create.c
+++ b/python/pointless_create.c
@@ -284,17 +284,60 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 			RETURN_OOM(state);
 		}
 	// 1-dimensional numpy array
-	} else if (PyArray_Check(py_object)) {
-		// must be native/little-endian
-		if (PyDataType_BYTEORDER(py_object) != '=' && PyDataType_BYTEORDER != '<') {
-				PyErr_SetString(PyExc_ValueError, "only native/little endian numpy arrays supported");
+	} else if (PyArray_Check(py_object) && PyArray_NDIM(py_object) == 1) {
+		PyArray_Descr* descr = PyArray_DESCR(py_object);
+
+		size_t n_items = (size_t)PyArray_Size(py_object);
+		npy_intp zero = 0;
+		void* data = PyArray_GetPtr(py_object, &zero);
+
+		if (descr->byteorder != NPY_LITTLE || descr->byteorder != NPY_NATIVE) {
+			PyErr_SetString(PyExc_ValueError, "numpy array must be have native or little byteorder");
+			state->error_line = __LINE__;
+			state->is_error = 1;
+			return POINTLESS_CREATE_VALUE_FAIL;
+		}
+
+		switch (PyArray_TYPE(py_object)) {
+			case NPY_INT8:
+				handle = pointless_create_vector_i8_owner(&state->c, (int8_t*)data, n_items);
+				break;
+			case NPY_UINT8:
+				handle = pointless_create_vector_u8_owner(&state->c, (uint8_t*)data, n_items);
+				break;
+			case NPY_INT16:
+				handle = pointless_create_vector_i16_owner(&state->c, (int16_t*)data, n_items);
+				break;
+			case NPY_UINT16:
+				handle = pointless_create_vector_u16_owner(&state->c, (uint16_t*)data, n_items);
+				break;
+			case NPY_INT32:
+				handle = pointless_create_vector_i32_owner(&state->c, (int32_t*)data, n_items);
+				break;
+			case NPY_UINT32:
+				handle = pointless_create_vector_u32_owner(&state->c, (uint32_t*)data, n_items);
+				break;
+			case NPY_INT64:
+				handle = pointless_create_vector_i64_owner(&state->c, (int64_t*)data, n_items);
+				break;
+			case NPY_UINT64:
+				handle = pointless_create_vector_u64_owner(&state->c, (uint64_t*)data, n_items);
+				break;
+			case NPY_FLOAT32:
+				handle = pointless_create_vector_float_owner(&state->c, (float*)data, n_items);
+				break;
+			default:
+				PyErr_SetString(PyExc_ValueError, "unsupported dtype for numpy array");
 				state->error_line = __LINE__;
 				state->is_error = 1;
 				return POINTLESS_CREATE_VALUE_FAIL;
 		}
-		// and 1-dimensional
 
-		//!
+		RETURN_OOM_IF_FAIL(handle, state);
+
+		if (!pointless_export_set_seen(state, py_object, handle)) {
+			RETURN_OOM(state);
+		}
 	// unicode object
 	} else if (PyUnicode_Check(py_object)) {
 		Py_ssize_t s_len_python = PyUnicode_GET_LENGTH(py_object);

--- a/python/pointless_create.c
+++ b/python/pointless_create.c
@@ -284,12 +284,15 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 			RETURN_OOM(state);
 		}
 	// 1-dimensional numpy array
-	} else if (PyArray_Check(py_object) && PyArray_NDIM(py_object) == 1) {
-		PyArray_Descr* descr = PyArray_DESCR(py_object);
+	} else if (PyArray_Check(py_object)) {
+		if (PyArray_NDIM(py_object) != 1) {
+			PyErr_SetString(PyExc_ValueError, "numpy arrays must be 1-d");
+			state->error_line = __LINE__;
+			state->is_error = 1;
+			return POINTLESS_CREATE_VALUE_FAIL;
+		}
 
-		size_t n_items = (size_t)PyArray_Size(py_object);
-		npy_intp zero = 0;
-		void* data = PyArray_GetPtr(py_object, &zero);
+		PyArray_Descr* descr = PyArray_DESCR(py_object);
 
 		if (descr->byteorder != NPY_LITTLE || descr->byteorder != NPY_NATIVE) {
 			PyErr_SetString(PyExc_ValueError, "numpy array must be have native or little byteorder");
@@ -297,6 +300,10 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 			state->is_error = 1;
 			return POINTLESS_CREATE_VALUE_FAIL;
 		}
+
+		size_t n_items = (size_t)PyArray_Size(py_object);
+		npy_intp zero = 0;
+		void* data = PyArray_GetPtr(py_object, &zero);
 
 		switch (PyArray_TYPE(py_object)) {
 			case NPY_INT8:
@@ -575,7 +582,9 @@ const char pointless_write_object_doc[] =
 ;
 PyObject* pointless_write_object(PyObject* self, PyObject* args, PyObject* kwds)
 {
-	//! try to import numpy
+    if (PyArray_ImportNumPyAPI() < 0) {
+        return NULL;
+    }
 
 	const char* fname = 0;
 	PyObject* object = 0;

--- a/python/pointless_create.c
+++ b/python/pointless_create.c
@@ -294,7 +294,7 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 
 		PyArray_Descr* descr = PyArray_DESCR(py_object);
 
-		if (descr->byteorder != NPY_LITTLE || descr->byteorder != NPY_NATIVE) {
+		if (descr->byteorder != NPY_IGNORE && descr->byteorder != NPY_LITTLE && descr->byteorder != NPY_NATIVE) {
 			PyErr_SetString(PyExc_ValueError, "numpy array must be have native or little byteorder");
 			state->error_line = __LINE__;
 			state->is_error = 1;

--- a/python/pointless_create.c
+++ b/python/pointless_create.c
@@ -498,7 +498,8 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 					bm_set_(bits, i);
 			}
 
-			if (state->normalize_bitvector)
+			// we don't normalize really big bitvectors
+			if (state->normalize_bitvector && n_bits < 100000)
 				handle = pointless_create_bitvector(&state->c, bits, n_bits);
 			else
 				handle = pointless_create_bitvector_no_normalize(&state->c, bits, n_bits);

--- a/python/pointless_create.c
+++ b/python/pointless_create.c
@@ -283,7 +283,18 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 		if (!pointless_export_set_seen(state, py_object, handle)) {
 			RETURN_OOM(state);
 		}
+	// 1-dimensional numpy array
+	} else if (PyArray_Check(py_object)) {
+		// must be native/little-endian
+		if (PyDataType_BYTEORDER(py_object) != '=' && PyDataType_BYTEORDER != '<') {
+				PyErr_SetString(PyExc_ValueError, "only native/little endian numpy arrays supported");
+				state->error_line = __LINE__;
+				state->is_error = 1;
+				return POINTLESS_CREATE_VALUE_FAIL;
+		}
+		// and 1-dimensional
 
+		//!
 	// unicode object
 	} else if (PyUnicode_Check(py_object)) {
 		Py_ssize_t s_len_python = PyUnicode_GET_LENGTH(py_object);
@@ -521,6 +532,8 @@ const char pointless_write_object_doc[] =
 ;
 PyObject* pointless_write_object(PyObject* self, PyObject* args, PyObject* kwds)
 {
+	//! try to import numpy
+
 	const char* fname = 0;
 	PyObject* object = 0;
 	PyObject* retval = 0;

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import numpy
 from setuptools import Extension, setup
 
 
@@ -7,6 +8,7 @@ setup(
 			'pointless',
 			include_dirs=[
 				'./include',
+				numpy.get_include(),
 			],
 			sources=[
 				# python stuff


### PR DESCRIPTION
We now support zero-copy serialization of numpy vectors, with the following caveats:

1. they must be 1-dimensional
2. they must be little or native endian
3. they must be one of i8/u8/i16/u16/i32/u32/i64/u64/float32 dtypes