### PR TITLE
fix missing numpy import in `serialize_to_bytes`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.33"
+version = "1.0.34"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.11"

--- a/python/pointless_create.c
+++ b/python/pointless_create.c
@@ -650,6 +650,10 @@ const char pointless_write_object_to_bytes_doc[] =
 
 PyObject* pointless_write_object_to_bytes(PyObject* self, PyObject* args, PyObject* kwds)
 {
+    if (PyArray_ImportNumPyAPI() < 0) {
+        return NULL;
+    }
+
 	PyObject* object = 0;
 	PyObject* retval = 0;
 	PyObject* normalize_bitvector = Py_True;


### PR DESCRIPTION
This caused a segfault when consulting if an object is a numpy array