### PR TITLE
fix corruption of strings holding code points above the BMP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pointless"
-version = "1.0.35"
+version = "1.0.36"
 description = "A read-only relocatable data structure for JSON like data, with C and Python APIs"
 authors = [{ name = "Arni Mar Jonsson", email = "arnimarj@gmail.com" }]
 requires-python = ">=3.11"

--- a/python/pointless_create.c
+++ b/python/pointless_create.c
@@ -389,9 +389,9 @@ static uint32_t pointless_export_py_rec(pointless_export_state_t* state, PyObjec
 				break;
 			case PyUnicode_4BYTE_KIND:
 				if (state->unwiden_strings && pointless_is_ucs4_ascii((uint32_t*)python_buffer))
-					handle = pointless_create_unicode_ucs4(&state->c, (uint32_t*)python_buffer);
-				else
 					handle = pointless_create_string_ucs4(&state->c, (uint32_t*)python_buffer);
+				else
+					handle = pointless_create_unicode_ucs4(&state->c, (uint32_t*)python_buffer);
 				break;
 			// will happen for PyUnicode_WCHAR_KIND on python versions < 3.12
 			default:

--- a/tests/python_api/test_serialize.py
+++ b/tests/python_api/test_serialize.py
@@ -80,3 +80,23 @@ class TestSerialize(unittest.TestCase):
 		self.assertEqual(v[0], a)
 		self.assertEqual(v[1], b)
 		self.assertEqual(v[2], c)
+
+	def testWideString(self):
+		# strings holding code points above the BMP (which CPython stores with
+		# PyUnicode_4BYTE_KIND) must round-trip intact, whatever their position
+		# in the string, and regardless of unwiden_strings
+		fname = 'test_wide_string.map'
+
+		v = [
+			'\U0001f600smile',
+			'mid\U0001f600dle',
+			'trailing\U0001f600',
+			'\U00024176\U00023d13',
+			'ascii only',
+			chr(0xffff),
+		]
+
+		for unwiden_strings in (False, True):
+			pointless.serialize(v, fname, unwiden_strings = unwiden_strings)
+			root = pointless.Pointless(fname).GetRoot()
+			self.assertEqual(v, list(root))


### PR DESCRIPTION
The two PyUnicode_4BYTE_KIND branches in the serializer were swapped: strings which contained a code point above the BMP were passed through pointless_ucs4_to_ascii(), which casts each code point to a single byte, corrupting the string ('mid😀dle' -> 'mid', '𤅶𣴓' -> 'v\x13'), while pure-ASCII 4-byte-kind strings were stored as full UCS-4. Now ASCII strings are compacted and everything else is stored as UCS-4, mirroring the PyUnicode_2BYTE_KIND case above.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216521036999900